### PR TITLE
Add disk cleanup step to GitHub workflows for improved resource manag…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,23 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+    - name: 🧹 Free up disk space (diagnostic + cleanup)
+      run: |
+        set -euxo pipefail
+        echo "Disk usage before cleanup:"
+        df -h
+
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+
+        docker system prune -af --volumes || true
+        sudo apt-get clean || true
+
+        echo "Disk usage after cleanup:"
+        df -h
+
     - name: 📥 Checkout code
       uses: actions/checkout@v5
 
@@ -76,6 +93,23 @@ jobs:
     environment: pypi
 
     steps:
+    - name: 🧹 Free up disk space (diagnostic + cleanup)
+      run: |
+        set -euxo pipefail
+        echo "Disk usage before cleanup:"
+        df -h
+
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+
+        docker system prune -af --volumes || true
+        sudo apt-get clean || true
+
+        echo "Disk usage after cleanup:"
+        df -h
+
     - name: 📥 Checkout code
       uses: actions/checkout@v5
 


### PR DESCRIPTION
## Summary
- Add pre-run disk cleanup to both publish jobs (`test-before-publish`, `publish-pypi`) to avoid "No space left on device" failures
- Cleanup removes large preinstalled SDKs (dotnet, Android, GHC, CodeQL), prunes Docker (`docker system prune -af --volumes`), runs `apt-get clean`, and logs `df -h` before/after
- No code changes to the package itself; CI-only hardening for release pipeline

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] CI/CD changes

## Testing
- [ ] Not run
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual verification (workflow logic only)

(Please re-run the publish workflow to confirm the cleanup resolves the disk space issue.)