### PR TITLE
Add Wandb backend support for MetricWriter

### DIFF
--- a/docs/en/guide/metrics.md
+++ b/docs/en/guide/metrics.md
@@ -318,6 +318,69 @@ self.writer.close()
     `add_histogram` call. This forces every agent to think about the X-axis
     and guarantees that runs overlay correctly on shared charts.
 
+## Wandb backend
+
+`MetricWriter` supports Weights & Biases as a second sink alongside
+TensorBoard. Both can be active at the same time — every `add_scalar` /
+`add_histogram` / `log_episode` call fans out to whichever sinks are
+enabled.
+
+### When wandb is enabled
+
+| `tb_log_dir` | `wandb_project` | `WANDB_API_KEY` | TB | wandb |
+|---|---|---|---|---|
+| set | — | — | ✅ | — |
+| set | — | set | ✅ | ✅ (project = `algo`) |
+| — | — | set | — | ✅ (project = `algo`) |
+| set | set | * | ✅ | ✅ (project as given) |
+| — | set | unset | — | ✅ (calls `wandb.login()` interactively) |
+| — | — | unset | — | — |
+
+### Example
+
+```python
+from tensoraerospace.agent.sac.sac import SAC
+
+# TensorBoard only (default)
+agent = SAC(env=env, log_dir="runs/sac")
+
+# Wandb only — set WANDB_API_KEY in env, then:
+agent = SAC(
+    env=env,
+    wandb_project="my-experiment",
+    wandb_tags=["sac", "pendulum"],
+)
+
+# Both backends in parallel
+agent = SAC(
+    env=env,
+    log_dir="runs/sac",
+    wandb_project="my-experiment",
+    wandb_config={"lr": 3e-4, "tau": 5e-3},
+)
+```
+
+### Per-agent kwargs
+
+Every RL agent's `__init__` accepts these keyword arguments alongside
+`log_dir`:
+
+| Kwarg | Type | Description |
+|---|---|---|
+| `wandb_project` | `str \| None` | Wandb project name. Defaults to `algo` if `WANDB_API_KEY` is set. |
+| `wandb_entity` | `str \| None` | Wandb team/user namespace. Defaults to whatever `wandb` itself resolves. |
+| `wandb_run_name` | `str \| None` | Display name for this run. Defaults to `<algo>-<timestamp>`. |
+| `wandb_tags` | `list[str] \| None` | Tags to attach to the run. Defaults to `[algo]`. |
+| `wandb_config` | `dict \| None` | Hyperparameters dict that wandb stores with the run. |
+
+### A3C limitation
+
+A3C runs workers in forked processes. The wandb sink is initialized only
+in the main process — workers continue to share the parent's TensorBoard
+event file via the `/worker_<id>` suffix. To get per-worker wandb runs,
+launch one process per worker externally (each with its own
+`WANDB_RUN_GROUP`) instead of using `Agent.train()` directly.
+
 ## Adding a new algorithm
 
 1. **Edit `tensoraerospace/agent/metrics/schema.py`.** Add a new class named

--- a/docs/en/guide/metrics.md
+++ b/docs/en/guide/metrics.md
@@ -373,6 +373,80 @@ Every RL agent's `__init__` accepts these keyword arguments alongside
 | `wandb_tags` | `list[str] \| None` | Tags to attach to the run. Defaults to `[algo]`. |
 | `wandb_config` | `dict \| None` | Hyperparameters dict that wandb stores with the run. |
 
+### Authentication
+
+Three ways to authenticate with wandb:
+
+1. **`wandb login` CLI** (one-time setup) — runs interactively, stores the API key in `~/.netrc` so subsequent runs pick it up automatically.
+2. **`WANDB_API_KEY` env var** — easiest in CI; the key is read at sink-init time. If both `~/.netrc` and the env var are present, the env var wins.
+3. **Interactive prompt** — if no key is found and `wandb_project` is passed explicitly, `_WandbSink` calls `wandb.login()` which opens an interactive prompt (or a browser tab) to log in.
+
+In CI without a TTY, the interactive prompt fails — set `WANDB_API_KEY` as a pipeline secret.
+
+### Offline mode
+
+To run wandb without uploading anything (slow connections, air-gapped networks, debugging without polluting the cloud project):
+
+```bash
+export WANDB_MODE=offline
+```
+
+The sink still creates a local run directory under `wandb/`. Sync it later with:
+
+```bash
+wandb sync wandb/offline-run-*
+```
+
+To disable wandb entirely so that even the local run directory is not created, leave `WANDB_API_KEY` unset and do not pass `wandb_project`.
+
+### Hyperparameter tracking
+
+Use `wandb_config` to store training hyperparameters with the run. Wandb's UI then lets you sort, filter, and group runs by hyperparameter value:
+
+```python
+agent = SAC(
+    env=env,
+    wandb_project="sac-tuning",
+    wandb_config={
+        "lr": 3e-4,
+        "tau": 5e-3,
+        "batch_size": 256,
+        "buffer_size": 1_000_000,
+        "automatic_entropy_tuning": True,
+    },
+)
+```
+
+Anything passed in `wandb_config` is stored as a flat key-value snapshot with the run (visible in the wandb UI's "Config" panel) — separate from the time-series metrics. The snapshot is taken at `wandb.init()` time; later mutations to the dict are not reflected.
+
+### Grouping related runs
+
+For multi-seed experiments or hyperparameter sweeps, use the `WANDB_RUN_GROUP` env var to group related runs in the wandb UI:
+
+```bash
+export WANDB_RUN_GROUP="sac-pendulum-seed-sweep"
+
+for SEED in 0 1 2 3 4; do
+    python train_sac.py --seed=$SEED
+done
+```
+
+All five runs appear under one group in the wandb UI; the group view aggregates metrics with median plus percentile bands.
+
+### Best practices
+
+- **Always set `wandb_config`** for any run you might want to compare later. Two runs with identical metrics but no config are indistinguishable in the UI.
+- **Use `wandb_tags` for taxonomy** — `["sac", "pendulum", "ablation-no-target-update"]` instead of cramming everything into the run name. Tags are filterable in the UI.
+- **Do not put secrets in `wandb_config`.** It is uploaded verbatim and visible to anyone with project access.
+- **Pin `wandb_run_name`** for runs you'll reference in papers or reports. Wandb's auto-generated names (`prosperous-sea-42`) are catchy but not searchable; deterministic names like `sac-pendulum-seed-3-2026-04-20` are easier to cite.
+
+### Troubleshooting
+
+- **`wandb.errors.UsageError: api_key not configured`** — your `wandb login` ran for a different machine/user. Run `wandb login --relogin` or set `WANDB_API_KEY`.
+- **Run hangs at "Waiting for wandb.init()"** — usually a network or firewall issue. Try `export WANDB_MODE=offline` to verify training itself works, then sync later.
+- **Multiple agents in one Python process write to each other's runs** — should NOT happen. Each `_WandbSink` writes through its own captured run object (`self._run.log(...)`), not through wandb's module-level `wandb.log(...)` global state. If you observe this, file an issue.
+- **A3C workers do not appear in wandb** — by design (see the A3C limitation section below). Workers (forked) skip wandb-init even with `WANDB_API_KEY` set. To get per-worker wandb runs, launch one process per worker externally and rely on `WANDB_RUN_GROUP` to keep them together in the UI.
+
 ### A3C limitation
 
 A3C runs workers in forked processes. The wandb sink is initialized only

--- a/docs/ru/guide/metrics.md
+++ b/docs/ru/guide/metrics.md
@@ -1,0 +1,507 @@
+# Метрики TensorBoard
+
+> :material-chart-line: Унифицированная схема TensorBoard для всех RL-агентов в TensorAeroSpace.
+
+Все RL-агенты в TensorAeroSpace записывают скаляры и гистограммы TensorBoard
+через единый `MetricWriter`, пространство имён тегов которого определено в
+`tensoraerospace.agent.metrics.schema`. Поскольку каждый агент использует
+одинаковые имена, общую ось (накопленные шаги среды) и одинаковый минимальный
+набор метрик, запуски PPO, SAC, DQN, ADP, GAIL и других корректно
+накладываются друг на друга на одном графике TensorBoard.
+
+!!! note
+    Старые запуски, записанные с предыдущим, специфичным для конкретного
+    агента, наименованием не будут совмещаться с новыми запусками на одном
+    графике. Унификация — это жёсткое переименование, легаси-карта алиасов
+    была удалена.
+
+## Зачем нужна единая схема
+
+До унификации одна и та же величина логировалась под разными именами в
+зависимости от агента — `Performance/Episode_Reward`, `Performance/Reward`,
+`performance/episode_reward`, `episode_reward` и так далее. Префиксы для
+loss-ов смешивались между `Loss/`, `loss/` и `losses/`. Ось X в одних
+случаях была индексом эпизода, в других — накопленным числом шагов среды,
+из-за чего сравнения агентов на одном графике становились некорректными.
+
+Единая схема решает все три проблемы сразу:
+
+- Одно каноническое имя на каждую величину (`lowercase_snake_case`, `/` как разделитель групп).
+- Одна ось: `env_step` — обязательный аргумент в каждом вызове `add_scalar`.
+- Один обязательный минимум, который должен логировать каждый RL-агент,
+  чтобы любые два агента всегда были сравнимы хотя бы по базовым метрикам
+  rollout/training.
+
+## Префиксы групп
+
+| Префикс | Назначение |
+|---|---|
+| `rollout/` | Поэпизодная статистика среды (награда, длина, общее число шагов). |
+| `loss/` | Тренировочные потери (actor, critic, entropy, value, policy и специфичные для алгоритма). |
+| `policy/` | Статистика политики / действий (entropy, std действий, среднее log-pi). |
+| `value/` | Статистика value-функции (среднее V, TD-цели, TD-ошибки, advantages). |
+| `diagnostics/` | Специфичные для алгоритма диагностики (KL, clip fraction, accuracy). |
+| `train/` | Счётчики прогресса обучения (updates, learning rate, размер replay-буфера). |
+| `eval/` | Статистика эпизодов оценки (награда, длина). |
+| `weights/` | Гистограммы весов сетей (`weights/<group>/<param>`). |
+| `grads/` | Гистограммы градиентов (`grads/<group>/<param>`). |
+
+## Tier 1 — Обязательный минимум
+
+Каждый RL-агент обязан логировать перечисленные ниже метрики. Их наличие
+проверяется в конце `train()` функцией `assert_contract_satisfied()`.
+
+| Константа | Тег | Примечания |
+|---|---|---|
+| `ROLLOUT_EPISODE_REWARD` | `rollout/episode_reward` | пишется в конце эпизода |
+| `ROLLOUT_EPISODE_LENGTH` | `rollout/episode_length` | пишется в конце эпизода |
+| `ROLLOUT_TOTAL_STEPS` | `rollout/total_steps` | накопленные шаги среды |
+| `TRAIN_UPDATES` | `train/updates` | накопленные градиентные обновления |
+| `TRAIN_LR` | `train/lr` | текущий learning rate (агенты с константным LR могут писать его один раз в начале) |
+
+`EVAL_EPISODE_REWARD` (`eval/episode_reward`) и `EVAL_EPISODE_LENGTH`
+(`eval/episode_length`) обязательны только если агент выполняет цикл оценки.
+
+## Tier 2 — Общие константы
+
+Эти метрики логируются, если соответствующая величина существует в
+алгоритме. Они объявлены как константы уровня модуля в
+`tensoraerospace.agent.metrics.schema`.
+
+### `loss/*`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `LOSS_ACTOR` | `loss/actor` | Loss актора / policy gradient. |
+| `LOSS_CRITIC` | `loss/critic` | Loss критика / value-функции для actor-critic методов. |
+| `LOSS_ENTROPY` | `loss/entropy` | Член энтропийной регуляризации. |
+| `LOSS_VALUE` | `loss/value` | Отдельный value loss (когда отличается от `loss/critic`). |
+| `LOSS_POLICY` | `loss/policy` | Policy loss для off-policy actor-critic (SAC, DDPG). |
+
+### `train/*`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `TRAIN_REPLAY_SIZE` | `train/replay_size` | Текущая заполненность replay-буфера (off-policy). |
+
+### `policy/*`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `POLICY_ENTROPY` | `policy/entropy` | Дифференциальная энтропия текущей политики. |
+| `POLICY_ACTION_STD` | `policy/action_std` | Среднее по размерностям стандартное отклонение распределения действий. |
+| `POLICY_ACTION_ABS_MEAN` | `policy/action_abs_mean` | Среднее по абсолютной величине действий (индикатор насыщения). |
+
+### `value/*`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `VALUE_MEAN` | `value/mean` | Среднее V(s) по батчу. |
+| `VALUE_TD_TARGET` | `value/td_target_mean` | Среднее TD-цели. |
+| `VALUE_TD_ERROR_MEAN` | `value/td_error_mean` | Средняя TD-ошибка (target − prediction). |
+| `VALUE_TD_ERROR_MAX` | `value/td_error_max` | Максимальная TD-ошибка в батче. |
+| `VALUE_TD_ERROR_MIN` | `value/td_error_min` | Минимальная TD-ошибка в батче. |
+
+### `diagnostics/*`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `DIAG_TERMINATED_COUNT` | `diagnostics/terminated_count` | Число завершённых (terminated) эпизодов с момента последнего лога. |
+| `DIAG_TRUNCATED_COUNT` | `diagnostics/truncated_count` | Число оборванных (truncated) эпизодов с момента последнего лога. |
+
+### `eval/*`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `EVAL_EPISODE_REWARD` | `eval/episode_reward` | Награда эпизода оценки. |
+| `EVAL_EPISODE_LENGTH` | `eval/episode_length` | Длина эпизода оценки. |
+
+## Tier 3 — Специфичные для алгоритма метрики
+
+У каждого алгоритма есть собственный класс с пространством имён внутри
+`schema.py`. Теги по-прежнему используют общие префиксы групп, поэтому
+группы TensorBoard остаются консистентными между запусками.
+
+### PPO
+
+`from tensoraerospace.agent.metrics.schema import PPO`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `PPO.APPROX_KL` | `diagnostics/approx_kl` | Эмпирический KL между старой и новой политикой. |
+| `PPO.CLIP_FRACTION` | `diagnostics/clip_fraction` | Доля сэмплов, попадающих в границу clip. |
+| `PPO.EXPLAINED_VARIANCE` | `diagnostics/explained_variance` | 1 − Var(returns − V) / Var(returns). |
+| `PPO.REWARD_MEDIAN` | `rollout/episode_reward_median` | Медиана награды эпизодов в окне rollout. |
+| `PPO.REWARD_P10` | `rollout/episode_reward_p10` | 10-й перцентиль наград эпизодов (нижняя граница). |
+| `PPO.REWARD_P90` | `rollout/episode_reward_p90` | 90-й перцентиль наград эпизодов (верхняя граница). |
+
+### SAC
+
+`from tensoraerospace.agent.metrics.schema import SAC`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `SAC.LOSS_Q1` | `loss/q1` | Loss первой Q-сети. |
+| `SAC.LOSS_Q2` | `loss/q2` | Loss второй Q-сети. |
+| `SAC.LOSS_ALPHA` | `loss/alpha` | Loss параметра температуры. |
+| `SAC.ALPHA_VALUE` | `policy/alpha` | Текущая температура энтропии α. |
+| `SAC.Q_MEAN` | `value/q_mean` | Среднее Q(s, a) по батчу. |
+| `SAC.LOG_PI_MEAN` | `policy/log_pi_mean` | Среднее log π(a|s) для сэмплированных действий. |
+
+SAC также использует общие константы `LOSS_POLICY` (`loss/policy`) и
+`TRAIN_REPLAY_SIZE` (`train/replay_size`).
+
+### DSAC
+
+`from tensoraerospace.agent.metrics.schema import DSAC`
+
+DSAC наследует все имена SAC и добавляет члены регуляризации CAPS.
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `DSAC.CAPS_SPATIAL` | `loss/caps_spatial` | Пространственный штраф гладкости CAPS. |
+| `DSAC.CAPS_TEMPORAL` | `loss/caps_temporal` | Временной штраф гладкости CAPS. |
+
+### DQN
+
+`from tensoraerospace.agent.metrics.schema import DQN`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `DQN.LOSS_Q` | `loss/q` | Loss Беллмана / Хьюбера на Q-значениях. |
+| `DQN.Q_PRED_SA_MEAN` | `value/q_pred_mean` | Среднее предсказанное Q(s, a). |
+| `DQN.Q_TARGET_SA_MEAN` | `value/q_target_mean` | Среднее target Q(s, a). |
+| `DQN.EPSILON` | `train/epsilon` | Текущее ε для ε-greedy исследования. |
+| `DQN.PER_BETA` | `train/per_beta` | Показатель importance-sampling β для prioritized replay. |
+| `DQN.TARGET_UPDATE` | `train/target_update` | Счётчик обновлений target-сети. |
+
+DQN также использует общую константу `TRAIN_REPLAY_SIZE` (`train/replay_size`).
+
+### DDPG
+
+`from tensoraerospace.agent.metrics.schema import DDPG`
+
+У DDPG нет собственных DDPG-специфичных тегов. Он использует только общие
+константы Tier 2: `LOSS_POLICY` (`loss/policy`), `LOSS_VALUE` (`loss/value`)
+и `TRAIN_REPLAY_SIZE` (`train/replay_size`).
+
+### A2C
+
+`from tensoraerospace.agent.metrics.schema import A2C`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `A2C.ADVANTAGE_MEAN` | `value/advantage_mean` | Среднее advantage до нормализации. |
+| `A2C.ADVANTAGE_STD` | `value/advantage_std` | Std advantage до нормализации. |
+| `A2C.ADVANTAGE_NORMALIZED_MEAN` | `value/advantage_normalized_mean` | Среднее нормализованного advantage. |
+| `A2C.VALUE_BEFORE_UPDATE` | `value/before_update_mean` | Среднее V(s) до градиентного обновления. |
+| `A2C.ENTROPY_BETA` | `policy/entropy_beta` | Текущий коэффициент энтропийной регуляризации β. |
+
+### ADP
+
+`from tensoraerospace.agent.metrics.schema import ADP`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `ADP.DHP_PHASE_EPISODE` | `train/dhp_phase_episode` | Индекс эпизода внутри текущей фазы DHP. |
+| `ADP.LOSS_ACTOR_HDP` | `loss/actor_hdp` | Loss актора в HDP-варианте. |
+| `ADP.LOSS_ACTOR_GDHP` | `loss/actor_adgdhp` | Loss актора в AD-GDHP варианте. |
+| `ADP.LOSS_CRITIC_HDP` | `loss/critic_hdp` | Loss критика в HDP-варианте. |
+| `ADP.LOSS_CRITIC_GDHP` | `loss/critic_gdhp` | Loss критика в GDHP-варианте. |
+| `ADP.LOSS_CRITIC_LAMBDA` | `loss/critic_lambda` | Loss критика, взвешенный по λ. |
+
+### ADHDP
+
+`from tensoraerospace.agent.metrics.schema import ADHDP`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `ADHDP.DO_CRITIC` | `train/do_critic` | 1, если критик обновлялся на этом шаге, иначе 0. |
+| `ADHDP.DO_ACTOR` | `train/do_actor` | 1, если актор обновлялся на этом шаге, иначе 0. |
+| `ADHDP.ACTION_SAT_FRAC` | `policy/action_sat_frac` | Доля действий, попадающих в границы насыщения. |
+
+### GAIL
+
+`from tensoraerospace.agent.metrics.schema import GAIL`
+
+| Константа | Тег | Краткое описание |
+|---|---|---|
+| `GAIL.LOSS_DISCRIMINATOR` | `loss/discriminator` | BCE-loss дискриминатора. |
+| `GAIL.LOSS_GENERATOR` | `loss/generator` | Loss генератора (политики) против оценки дискриминатора. |
+| `GAIL.EXPERT_ACCURACY` | `diagnostics/expert_accuracy` | Точность дискриминатора на экспертных переходах. |
+| `GAIL.POLICY_ACCURACY` | `diagnostics/policy_accuracy` | Точность дискриминатора на переходах политики. |
+
+## Конвенция для multi-worker
+
+Для агентов с несколькими параллельными воркерами (в первую очередь A3C)
+поворкерные скаляры используют **суффикс** `/worker_<id>`, чтобы префикс
+группы оставался общим, и TensorBoard размещал всех воркеров в одной группе.
+
+```text
+rollout/episode_reward/worker_0
+rollout/episode_reward/worker_1
+loss/actor/worker_0
+loss/actor/worker_1
+```
+
+`MetricWriter` валидирует такие теги, отрезая хвостовой сегмент
+`/worker_<N>` перед проверкой по реестру. Любой зарегистрированный тег
+скаляра можно дополнить суффиксом `/worker_<N>`, где `<N>` —
+неотрицательное целое.
+
+## Конвенция для гистограмм
+
+Гистограммы используют выделенные группы верхнего уровня (`weights/`,
+`grads/`) с двумя уровнями вложенности:
+
+```text
+weights/actor/<param_name>
+weights/critic/<param_name>
+grads/actor/<param_name>
+grads/critic/<param_name>
+```
+
+`MetricWriter.add_histogram` валидирует первые два сегмента. Допустимые
+группы верхнего уровня (`HISTOGRAM_GROUPS`) — `weights` и `grads`.
+Допустимые подгруппы (`HISTOGRAM_SUBGROUPS`):
+
+| Подгруппа | Используется в |
+|---|---|
+| `actor` | actor-critic агенты (PPO, A2C, DDPG, SAC, DSAC, ADP, ADHDP) |
+| `critic` | actor-critic агенты (PPO, A2C, DDPG, SAC, DSAC, ADP, ADHDP) |
+| `policy` | агенты только с политикой и политики SAC-стиля |
+| `value` | отдельные value-сети |
+| `q` | Q-сеть DQN |
+| `q1`, `q2` | сдвоенные Q-сети SAC / DSAC |
+| `discriminator` | дискриминатор GAIL |
+
+## Пример end-to-end
+
+```python
+from tensoraerospace.agent.metrics import MetricWriter, schema
+from tensoraerospace.agent.metrics.schema import (
+    LOSS_ACTOR,
+    LOSS_CRITIC,
+    POLICY_ENTROPY,
+    PPO,
+)
+
+# Создаём writer со строгим whitelist и тегом алгоритма.
+self.writer = MetricWriter(log_dir=self.log_dir, algo="ppo")
+
+# Внутри update() — каждый скаляр требует env_step.
+self.writer.add_scalar(LOSS_ACTOR,    actor_loss,  env_step=self.global_step)
+self.writer.add_scalar(LOSS_CRITIC,   critic_loss, env_step=self.global_step)
+self.writer.add_scalar(POLICY_ENTROPY, entropy,    env_step=self.global_step)
+
+# Специфичные для алгоритма метрики (PPO).
+self.writer.add_scalar(PPO.APPROX_KL,     kl,          env_step=self.global_step)
+self.writer.add_scalar(PPO.CLIP_FRACTION, clip_frac,   env_step=self.global_step)
+
+# Гистограммы (валидируются правилом weights/<group>/<param>).
+for name, p in self.actor.named_parameters():
+    self.writer.add_histogram(f"weights/actor/{name}", p, env_step=self.global_step)
+    if p.grad is not None:
+        self.writer.add_histogram(f"grads/actor/{name}", p.grad, env_step=self.global_step)
+
+# В конце эпизода — атомарная запись обязательного минимума rollout/*.
+self.writer.log_episode(
+    reward=ep_reward,
+    length=ep_length,
+    env_step=self.global_step,
+    terminated=terminated,
+    truncated=truncated,
+)
+
+# В конце train() — громко падаем, если какой-то обязательный тег так и не был записан.
+self.writer.assert_contract_satisfied()
+self.writer.close()
+```
+
+!!! tip
+    `env_step` — обязательный именованный аргумент в каждом вызове
+    `add_scalar` и `add_histogram`. Это вынуждает каждого агента
+    задумываться об оси X и гарантирует корректное наложение запусков на
+    общих графиках.
+
+## Бэкенд Wandb
+
+`MetricWriter` поддерживает Weights & Biases как второй sink наряду с
+TensorBoard. Оба бэкенда могут быть активны одновременно — каждый вызов
+`add_scalar` / `add_histogram` / `log_episode` рассылается во все
+включённые sink-и.
+
+### Когда wandb активен
+
+| `tb_log_dir` | `wandb_project` | `WANDB_API_KEY` | TB | wandb |
+|---|---|---|---|---|
+| set | — | — | ✅ | — |
+| set | — | set | ✅ | ✅ (project = `algo`) |
+| — | — | set | — | ✅ (project = `algo`) |
+| set | set | * | ✅ | ✅ (project как задан) |
+| — | set | unset | — | ✅ (вызывает `wandb.login()` интерактивно) |
+| — | — | unset | — | — |
+
+### Пример
+
+```python
+from tensoraerospace.agent.sac.sac import SAC
+
+# Только TensorBoard (по умолчанию)
+agent = SAC(env=env, log_dir="runs/sac")
+
+# Только wandb — установите WANDB_API_KEY в окружении, затем:
+agent = SAC(
+    env=env,
+    wandb_project="my-experiment",
+    wandb_tags=["sac", "pendulum"],
+)
+
+# Оба бэкенда параллельно
+agent = SAC(
+    env=env,
+    log_dir="runs/sac",
+    wandb_project="my-experiment",
+    wandb_config={"lr": 3e-4, "tau": 5e-3},
+)
+```
+
+### Параметры агента (kwargs)
+
+`__init__` каждого RL-агента принимает следующие именованные аргументы
+наряду с `log_dir`:
+
+| Kwarg | Тип | Описание |
+|---|---|---|
+| `wandb_project` | `str \| None` | Имя проекта wandb. По умолчанию равно `algo`, если установлен `WANDB_API_KEY`. |
+| `wandb_entity` | `str \| None` | Пространство имён команды/пользователя wandb. По умолчанию используется то, что выбирает сам `wandb`. |
+| `wandb_run_name` | `str \| None` | Отображаемое имя запуска. По умолчанию `<algo>-<timestamp>`. |
+| `wandb_tags` | `list[str] \| None` | Теги, привязанные к запуску. По умолчанию `[algo]`. |
+| `wandb_config` | `dict \| None` | Словарь гиперпараметров, сохраняемый wandb вместе с запуском. |
+
+### Аутентификация
+
+Есть три способа аутентификации в wandb:
+
+1. **CLI `wandb login`** (одноразовая настройка) — запускается интерактивно, сохраняет API-ключ в `~/.netrc`, чтобы последующие запуски подхватывали его автоматически.
+2. **Переменная окружения `WANDB_API_KEY`** — самый простой вариант для CI; ключ читается на этапе инициализации sink-а. Если одновременно присутствуют `~/.netrc` и переменная окружения, побеждает переменная окружения.
+3. **Интерактивный запрос** — если ключ не найден, а `wandb_project` передан явно, `_WandbSink` вызывает `wandb.login()`, который открывает интерактивный запрос (или вкладку браузера) для входа.
+
+В CI без TTY интерактивный запрос завершится ошибкой — задайте `WANDB_API_KEY` как секрет пайплайна.
+
+### Офлайн-режим
+
+Чтобы запускать wandb без отправки данных (медленные соединения, изолированные сети, отладка без засорения облачного проекта):
+
+```bash
+export WANDB_MODE=offline
+```
+
+Sink всё равно создаст локальную директорию запуска внутри `wandb/`. Синхронизировать её позже можно командой:
+
+```bash
+wandb sync wandb/offline-run-*
+```
+
+Чтобы полностью отключить wandb так, чтобы даже локальная директория запуска не создавалась, не задавайте `WANDB_API_KEY` и не передавайте `wandb_project`.
+
+### Отслеживание гиперпараметров
+
+Используйте `wandb_config`, чтобы сохранять гиперпараметры обучения вместе с запуском. UI wandb позволяет затем сортировать, фильтровать и группировать запуски по значениям гиперпараметров:
+
+```python
+agent = SAC(
+    env=env,
+    wandb_project="sac-tuning",
+    wandb_config={
+        "lr": 3e-4,
+        "tau": 5e-3,
+        "batch_size": 256,
+        "buffer_size": 1_000_000,
+        "automatic_entropy_tuning": True,
+    },
+)
+```
+
+Всё, что передано в `wandb_config`, сохраняется как плоский снимок «ключ-значение» вместе с запуском (отображается в панели «Config» UI wandb) — отдельно от метрик-временных рядов. Снимок делается в момент `wandb.init()`; последующие изменения словаря не отражаются.
+
+### Группировка связанных запусков
+
+Для экспериментов с несколькими сидами или sweep-ов по гиперпараметрам используйте переменную окружения `WANDB_RUN_GROUP`, чтобы сгруппировать связанные запуски в UI wandb:
+
+```bash
+export WANDB_RUN_GROUP="sac-pendulum-seed-sweep"
+
+for SEED in 0 1 2 3 4; do
+    python train_sac.py --seed=$SEED
+done
+```
+
+Все пять запусков появятся в одной группе в UI wandb; представление группы агрегирует метрики медианой и полосами перцентилей.
+
+### Рекомендации
+
+- **Всегда задавайте `wandb_config`** для любого запуска, который вы потенциально захотите сравнивать позже. Два запуска с одинаковыми метриками, но без конфигурации, неразличимы в UI.
+- **Используйте `wandb_tags` как таксономию** — `["sac", "pendulum", "ablation-no-target-update"]` вместо того, чтобы упихивать всё в имя запуска. Теги фильтруются в UI.
+- **Не помещайте секреты в `wandb_config`.** Он загружается как есть и виден всем, у кого есть доступ к проекту.
+- **Фиксируйте `wandb_run_name`** для запусков, на которые вы будете ссылаться в статьях или отчётах. Автогенерируемые имена wandb (`prosperous-sea-42`) запоминаются, но непригодны для поиска; детерминированные имена вида `sac-pendulum-seed-3-2026-04-20` проще цитировать.
+
+### Диагностика
+
+- **`wandb.errors.UsageError: api_key not configured`** — ваш `wandb login` отработал на другой машине/пользователе. Запустите `wandb login --relogin` или задайте `WANDB_API_KEY`.
+- **Запуск зависает на «Waiting for wandb.init()»** — обычно это сетевая проблема или фаервол. Попробуйте `export WANDB_MODE=offline`, чтобы убедиться, что само обучение работает, и синхронизировать данные позже.
+- **Несколько агентов в одном Python-процессе пишут в чужие запуски** — этого происходить НЕ должно. Каждый `_WandbSink` пишет через свой захваченный объект run (`self._run.log(...)`), а не через модульное глобальное состояние `wandb.log(...)`. Если вы наблюдаете такое поведение — заведите issue.
+- **Воркеры A3C не появляются в wandb** — это by design (см. раздел про ограничение A3C ниже). Воркеры (форкнутые) пропускают инициализацию wandb даже при заданном `WANDB_API_KEY`. Чтобы получить отдельные wandb-запуски на каждого воркера, запускайте по одному процессу на воркер вне фреймворка и используйте `WANDB_RUN_GROUP`, чтобы держать их вместе в UI.
+
+### Ограничение A3C
+
+A3C запускает воркеров в форкнутых процессах. Sink wandb инициализируется
+только в главном процессе — воркеры по-прежнему делят с родителем общий
+event-файл TensorBoard через суффикс `/worker_<id>`. Чтобы получить
+отдельные wandb-запуски на каждого воркера, запускайте по одному процессу
+на воркер вне фреймворка (каждый со своим `WANDB_RUN_GROUP`), а не через
+прямой вызов `Agent.train()`.
+
+## Как добавить новый алгоритм
+
+1. **Отредактируйте `tensoraerospace/agent/metrics/schema.py`.** Добавьте
+   новый класс с именем по алгоритму:
+
+   ```python
+   class MyAlgo:
+       MY_LOSS = "loss/my_term"
+       MY_DIAG = "diagnostics/my_signal"
+   ```
+
+   Переиспользуйте существующие префиксы групп (`loss/`, `policy/`,
+   `value/`, `train/`, `diagnostics/`, `rollout/`, `eval/`), чтобы группы
+   TensorBoard оставались консистентными. Теги должны быть в
+   `lowercase_snake_case` с `/` в качестве разделителя групп и без
+   пробелов.
+
+2. **Зарегистрируйте класс в `_build_registry()`.** Добавьте `MyAlgo` в
+   кортеж классов, перебираемых внутри `_build_registry()`, чтобы его
+   константы попали в `REGISTRY`:
+
+   ```python
+   for cls in (PPO, SAC, DSAC, DQN, DDPG, A2C, ADP, ADHDP, GAIL, MyAlgo):
+       parts.append(_collect_constants(cls))
+   ```
+
+3. **Используйте константы из вашего агента.** Импортируйте их по имени;
+   никогда не используйте свободные строковые литералы для тегов:
+
+   ```python
+   from tensoraerospace.agent.metrics.schema import MyAlgo
+   self.writer.add_scalar(MyAlgo.MY_LOSS, loss, env_step=self.global_step)
+   ```
+
+4. **Запустите unit-тесты схемы и writer-а.** Они выявят дублирующиеся
+   значения тегов, некорректно сформированные имена и любые новые
+   константы, отсутствующие в `REGISTRY`.
+
+## Справочные ссылки
+
+- Канонический источник: `tensoraerospace/agent/metrics/schema.py`
+- Реализация writer-а: `tensoraerospace/agent/metrics/writer.py`
+- Хелпер контракта: `tensoraerospace/agent/metrics/contract.py`

--- a/docs/superpowers/plans/2026-04-20-wandb-backend.md
+++ b/docs/superpowers/plans/2026-04-20-wandb-backend.md
@@ -1,0 +1,1289 @@
+# Wandb Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Weights & Biases as a second sink for `MetricWriter` alongside the existing TensorBoard sink, with auto-detection via `WANDB_API_KEY` and per-backend kwargs override.
+
+**Architecture:** Refactor `MetricWriter` into a façade holding `0..N` private `_Sink` objects. `_TensorBoardSink` wraps the existing `SummaryWriter` path; new `_WandbSink` wraps `wandb.init()` + `wandb.log(...)`. Strict-whitelist validation stays in the façade — sinks never validate. Factory `create_metric_writer(...)` auto-activates wandb when `WANDB_API_KEY` is set, or when `wandb_project` is passed explicitly. Each of the 12 RL agents gains five wandb kwargs in `__init__` and forwards them.
+
+**Tech Stack:** Python 3.10+, `wandb` (~0.18+), `torch.utils.tensorboard.SummaryWriter`, `pytest`, `unittest.mock`.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-wandb-backend-design.md`
+
+---
+
+## File Structure
+
+**Modified:**
+- `pyproject.toml` — add `wandb` to dependencies
+- `tensoraerospace/agent/metrics/writer.py` — refactor to sinks; add `_TensorBoardSink`, `_WandbSink`, factory auto-detection
+- `tensoraerospace/agent/metrics/__init__.py` — re-export unchanged surface
+- `tensoraerospace/agent/a2c/model.py`, `a2c/narx.py`, `a3c/pytorch.py`, `adhdp/model.py`, `adp/adp.py`, `ddpg/model.py`, `dqn/model.py`, `dsac/dsac_flight.py`, `et_dhp/model.py`, `gail/model.py`, `ppo/model.py`, `sac/sac.py` — extend `__init__` with 5 wandb kwargs and forward to `create_metric_writer`
+- `tests/agents/metrics_writer_test.py` — rename `log_dir=` → `tb_log_dir=`
+- `docs/en/guide/metrics.md` — add "Wandb backend" section
+
+**Created:**
+- `tests/agents/metrics_wandb_sink_test.py` — `_WandbSink` unit tests with mocked wandb
+- `tests/agents/metrics_factory_test.py` — auto-activation table tests
+- `tests/agents/metrics_dual_sink_smoke_test.py` — dual-sink end-to-end
+- `tests/agents/a3c_wandb_parent_only_test.py` — multi-worker exclusion test
+
+---
+
+## Task 1: Add wandb to project dependencies
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Inspect current dependencies block**
+
+Run: `grep -n -A 30 '\[tool\.poetry\.dependencies\]\|\[project\]' pyproject.toml | head -60`
+
+Identify the dependencies table (poetry-style `[tool.poetry.dependencies]` or PEP 621 `[project] dependencies = [...]`).
+
+- [ ] **Step 2: Add wandb dependency**
+
+If poetry-style:
+```toml
+[tool.poetry.dependencies]
+# ... existing entries ...
+wandb = "^0.18"
+```
+
+If PEP 621-style:
+```toml
+[project]
+dependencies = [
+    # ... existing entries ...
+    "wandb>=0.18,<1.0",
+]
+```
+
+Use whichever style the file already uses; do not migrate styles.
+
+- [ ] **Step 3: Install the dependency**
+
+Run (whichever the project uses):
+```bash
+.venv/bin/pip install "wandb>=0.18,<1.0"
+```
+or
+```bash
+poetry install
+```
+
+Verify:
+```bash
+.venv/bin/python -c "import wandb; print(wandb.__version__)"
+```
+Expected: prints a version `0.18.x` or `0.19.x` (no error).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml
+# also commit the lockfile if your project uses one (poetry.lock / uv.lock / etc.)
+git add poetry.lock 2>/dev/null || true
+git commit -m "deps: add wandb for second metrics sink"
+```
+
+---
+
+## Task 2: Extract `_TensorBoardSink` from `MetricWriter` (behavior-preserving refactor)
+
+**Files:**
+- Modify: `tensoraerospace/agent/metrics/writer.py`
+
+This task ONLY extracts the existing TB writing code into a `_TensorBoardSink` class and routes `MetricWriter` through it. Behavior is identical. No tests should change.
+
+- [ ] **Step 1: Read current `writer.py`**
+
+Run: `cat tensoraerospace/agent/metrics/writer.py`
+
+Identify:
+- `_FallbackSummaryWriter` (no-op summary writer)
+- `_get_summary_writer_class()`, `_LazyTorchSummaryWriter`, `TorchSummaryWriter` (lazy import proxy)
+- `MetricWriter.__init__` constructs `self._writer` via `TorchSummaryWriter(log_dir=...)`
+- `MetricWriter.add_scalar/add_histogram` calls `self._writer.add_scalar/add_histogram`
+- `MetricWriter.flush/close` forwards to `self._writer`
+
+- [ ] **Step 2: Add `_TensorBoardSink` class** (insert right above `class MetricWriter:`)
+
+```python
+class _TensorBoardSink:
+    """Sink that forwards metrics to a torch.utils.tensorboard.SummaryWriter."""
+
+    def __init__(self, log_dir: Optional[Union[str, Path]]) -> None:
+        log_path = str(log_dir) if log_dir is not None else None
+        self._writer = (
+            TorchSummaryWriter(log_dir=log_path)
+            if log_path is not None
+            else TorchSummaryWriter()
+        )
+
+    def add_scalar(self, tag: str, value: float, env_step: int) -> None:
+        self._writer.add_scalar(tag, value, env_step)
+
+    def add_histogram(self, tag: str, values, env_step: int) -> None:
+        self._writer.add_histogram(tag, values, env_step)
+
+    def flush(self) -> None:
+        self._writer.flush()
+
+    def close(self) -> None:
+        self._writer.close()
+```
+
+- [ ] **Step 3: Refactor `MetricWriter` to hold a list of sinks**
+
+Replace the existing `__init__`, `add_scalar`, `add_histogram`, `flush`, `close` with:
+
+```python
+class MetricWriter:
+    """SummaryWriter wrapper that enforces the canonical metric schema."""
+
+    def __init__(
+        self,
+        log_dir: Optional[Union[str, Path]] = None,
+        *,
+        strict: bool = True,
+        required: Iterable[str] = MANDATORY_METRICS,
+        algo: Optional[str] = None,
+    ) -> None:
+        self._sinks: list = [_TensorBoardSink(log_dir)]
+        self._strict = strict
+        self._required = tuple(required)
+        self._algo = algo
+        self._written: Set[str] = set()
+
+    def add_scalar(self, tag: str, value: float, env_step: int) -> None:
+        if self._strict and not schema.is_registered_scalar(tag):
+            raise ValueError(
+                f"Unknown metric tag {tag!r}"
+                + (f" (algo={self._algo})" if self._algo else "")
+                + ". Register it in tensoraerospace.agent.metrics.schema "
+                "or construct MetricWriter(strict=False)."
+            )
+        self._written.add(schema.strip_worker_suffix(tag))
+        for sink in self._sinks:
+            sink.add_scalar(tag, value, env_step)
+
+    def add_histogram(self, tag: str, values, env_step: int) -> None:
+        if self._strict and not schema.is_registered_histogram(tag):
+            raise ValueError(
+                f"Unknown histogram tag {tag!r}. "
+                "Histograms must match weights/<group>/<param> or "
+                "grads/<group>/<param> with <group> in "
+                f"{sorted(schema.HISTOGRAM_SUBGROUPS)}."
+            )
+        for sink in self._sinks:
+            sink.add_histogram(tag, values, env_step)
+
+    def log_episode(
+        self,
+        *,
+        reward: float,
+        length: int,
+        env_step: int,
+        terminated: Optional[bool] = None,
+        truncated: Optional[bool] = None,
+    ) -> None:
+        self.add_scalar(schema.ROLLOUT_EPISODE_REWARD, float(reward), env_step)
+        self.add_scalar(schema.ROLLOUT_EPISODE_LENGTH, int(length), env_step)
+        self.add_scalar(schema.ROLLOUT_TOTAL_STEPS, int(env_step), env_step)
+        if terminated is not None:
+            self.add_scalar(schema.DIAG_TERMINATED_COUNT, int(bool(terminated)), env_step)
+        if truncated is not None:
+            self.add_scalar(schema.DIAG_TRUNCATED_COUNT, int(bool(truncated)), env_step)
+
+    def assert_contract_satisfied(self) -> None:
+        check_contract(self._written, self._required)
+
+    def flush(self) -> None:
+        for sink in self._sinks:
+            sink.flush()
+
+    def close(self) -> None:
+        for sink in self._sinks:
+            sink.close()
+```
+
+- [ ] **Step 4: Run existing test suite to confirm no behavior change**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_schema_test.py tests/agents/metrics_writer_test.py tests/agents/metrics_contract_smoke_test.py -v
+```
+Expected: 7 + 12 + 1 = 20 PASSED.
+
+- [ ] **Step 5: Run full agent suite (sanity)**
+
+```bash
+.venv/bin/python -m pytest tests/agents/ --tb=short -q
+```
+Expected: 985 PASSED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tensoraerospace/agent/metrics/writer.py
+git commit -m "refactor(metrics): extract _TensorBoardSink from MetricWriter
+
+No behavior change. Prepares for dual-sink architecture in subsequent
+commits."
+```
+
+---
+
+## Task 3: Add `_WandbSink` class (TDD)
+
+**Files:**
+- Modify: `tensoraerospace/agent/metrics/writer.py`
+- Create: `tests/agents/metrics_wandb_sink_test.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/agents/metrics_wandb_sink_test.py`:
+
+```python
+"""Behaviour of tensoraerospace.agent.metrics.writer._WandbSink."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from tensoraerospace.agent.metrics import writer as writer_mod
+from tensoraerospace.agent.metrics.writer import _WandbSink
+
+
+@pytest.fixture
+def mock_wandb(monkeypatch):
+    """Provide a fresh mock for the `wandb` module with `Settings`, `init`,
+    `login`, `Histogram`, `finish`."""
+    mock = MagicMock()
+    mock.Histogram = MagicMock(side_effect=lambda v: ("HISTOGRAM", v))
+    mock.Settings = MagicMock(return_value="SETTINGS_OBJ")
+    mock_run = MagicMock()
+    mock.init = MagicMock(return_value=mock_run)
+    monkeypatch.setattr(writer_mod, "wandb", mock, raising=False)
+    return mock, mock_run
+
+
+def test_init_calls_wandb_init_with_kwargs(mock_wandb, monkeypatch):
+    mock, mock_run = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+
+    sink = _WandbSink(
+        project="proj-1",
+        entity="ent-1",
+        run_name="run-1",
+        tags=["sac", "pendulum"],
+        config={"lr": 1e-3},
+    )
+
+    mock.login.assert_not_called()
+    mock.init.assert_called_once()
+    kwargs = mock.init.call_args.kwargs
+    assert kwargs["project"] == "proj-1"
+    assert kwargs["entity"] == "ent-1"
+    assert kwargs["name"] == "run-1"
+    assert kwargs["tags"] == ["sac", "pendulum"]
+    assert kwargs["config"] == {"lr": 1e-3}
+    assert kwargs["reinit"] is True
+    assert kwargs["settings"] == "SETTINGS_OBJ"
+
+
+def test_init_calls_login_when_api_key_missing(mock_wandb, monkeypatch):
+    mock, _ = mock_wandb
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+
+    _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+
+    mock.login.assert_called_once()
+    mock.init.assert_called_once()
+
+
+def test_add_scalar_calls_wandb_log(mock_wandb, monkeypatch):
+    mock, _ = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+    sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+    mock.log.reset_mock()
+
+    sink.add_scalar("loss/actor", 0.123, env_step=10)
+
+    mock.log.assert_called_once_with({"loss/actor": 0.123}, step=10)
+
+
+def test_add_histogram_wraps_in_wandb_histogram(mock_wandb, monkeypatch):
+    mock, _ = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+    sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+    mock.log.reset_mock()
+
+    values = np.zeros(8)
+    sink.add_histogram("weights/actor/fc1", values, env_step=5)
+
+    mock.Histogram.assert_called_once_with(values)
+    mock.log.assert_called_once_with(
+        {"weights/actor/fc1": ("HISTOGRAM", values)}, step=5
+    )
+
+
+def test_close_calls_finish_once(mock_wandb, monkeypatch):
+    mock, mock_run = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+    sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+
+    sink.close()
+    sink.close()  # second call must be a no-op
+
+    mock_run.finish.assert_called_once()
+
+
+def test_flush_is_noop(mock_wandb, monkeypatch):
+    mock, _ = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+    sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+
+    # Should not raise; nothing to assert on the mock besides no exception.
+    sink.flush()
+```
+
+- [ ] **Step 2: Run the tests, expect collection error (no `_WandbSink` yet)**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_wandb_sink_test.py -v
+```
+Expected: ImportError or collection failure.
+
+- [ ] **Step 3: Add `_WandbSink` and the `wandb` module-level import to `writer.py`**
+
+At the top of `tensoraerospace/agent/metrics/writer.py`, add (alongside existing imports):
+
+```python
+import os
+import wandb  # type: ignore[import-untyped]
+```
+
+Add the class right after `_TensorBoardSink`:
+
+```python
+class _WandbSink:
+    """Sink that forwards metrics to Weights & Biases."""
+
+    def __init__(
+        self,
+        *,
+        project: str,
+        entity: Optional[str],
+        run_name: Optional[str],
+        tags: Optional[Sequence[str]],
+        config: Optional[Mapping[str, Any]],
+    ) -> None:
+        if not os.environ.get("WANDB_API_KEY"):
+            wandb.login()
+        self._run = wandb.init(
+            project=project,
+            entity=entity,
+            name=run_name,
+            tags=list(tags) if tags else None,
+            config=dict(config) if config else None,
+            reinit=True,
+            settings=wandb.Settings(start_method="thread"),
+        )
+
+    def add_scalar(self, tag: str, value: float, env_step: int) -> None:
+        wandb.log({tag: float(value)}, step=int(env_step))
+
+    def add_histogram(self, tag: str, values, env_step: int) -> None:
+        wandb.log({tag: wandb.Histogram(values)}, step=int(env_step))
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        if self._run is not None:
+            self._run.finish()
+            self._run = None
+```
+
+Update the `from typing import` line to include `Any, Mapping, Sequence` if not already present.
+
+- [ ] **Step 4: Run the tests, expect PASS**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_wandb_sink_test.py -v
+```
+Expected: 6 PASSED.
+
+- [ ] **Step 5: Run full metrics test suite (sanity)**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_*.py -v
+```
+Expected: all PASS (the new 6 + previously-passing 20 = 26).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tensoraerospace/agent/metrics/writer.py tests/agents/metrics_wandb_sink_test.py
+git commit -m "feat(metrics): add _WandbSink for wandb backend
+
+Mirrors _TensorBoardSink interface. Calls wandb.login() interactively
+when WANDB_API_KEY is unset. Uses thread start_method to stay safe under
+multiprocessing.fork (relevant for A3C). Histograms wrapped via
+wandb.Histogram."
+```
+
+---
+
+## Task 4: Add wandb kwargs to `MetricWriter.__init__` (TDD)
+
+**Files:**
+- Modify: `tensoraerospace/agent/metrics/writer.py`
+- Modify: `tests/agents/metrics_writer_test.py` (rename `log_dir=` → `tb_log_dir=`, add new tests)
+
+- [ ] **Step 1: Update `metrics_writer_test.py` to use the renamed kwarg**
+
+In `tests/agents/metrics_writer_test.py`, find the fixture:
+
+```python
+@pytest.fixture
+def writer(tmp_path: Path) -> MetricWriter:
+    return MetricWriter(log_dir=str(tmp_path / "tb"), algo="test")
+```
+
+and change to:
+
+```python
+@pytest.fixture
+def writer(tmp_path: Path) -> MetricWriter:
+    return MetricWriter(tb_log_dir=str(tmp_path / "tb"), algo="test")
+```
+
+Also update `test_add_scalar_strict_false_allows_anything`:
+```python
+def test_add_scalar_strict_false_allows_anything(tmp_path: Path):
+    w = MetricWriter(tb_log_dir=str(tmp_path / "tb"), strict=False)
+    w.add_scalar("anything/at/all", 1.0, env_step=1)
+```
+
+- [ ] **Step 2: Add new tests for wandb kwargs in the same file**
+
+Append to `tests/agents/metrics_writer_test.py`:
+
+```python
+def test_metricwriter_with_wandb_project_creates_two_sinks(
+    tmp_path: Path, monkeypatch
+):
+    """When both tb_log_dir and wandb_project are passed, both sinks are active."""
+    from unittest.mock import MagicMock
+    from tensoraerospace.agent.metrics import writer as writer_mod
+
+    mock_wandb = MagicMock()
+    mock_wandb.init = MagicMock(return_value=MagicMock())
+    mock_wandb.Settings = MagicMock(return_value="S")
+    monkeypatch.setattr(writer_mod, "wandb", mock_wandb, raising=False)
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+
+    w = MetricWriter(
+        tb_log_dir=str(tmp_path / "tb"),
+        wandb_project="exp",
+        algo="test",
+    )
+    assert len(w._sinks) == 2  # noqa: SLF001 — internal but stable for tests
+
+
+def test_metricwriter_no_kwargs_creates_zero_sinks(monkeypatch):
+    """No tb_log_dir and no wandb activation => zero sinks (writer no-ops)."""
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    w = MetricWriter(algo="test")
+    assert len(w._sinks) == 0
+    # whitelist still enforced
+    w.add_scalar(schema.LOSS_ACTOR, 0.5, env_step=1)
+    with pytest.raises(ValueError):
+        w.add_scalar("not/in/schema", 0.5, env_step=1)
+```
+
+- [ ] **Step 3: Run tests, expect failures (writer doesn't accept new kwargs yet)**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_writer_test.py -v
+```
+Expected: at least the two new tests fail (TypeError on `wandb_project`); existing 12 may also fail because `tb_log_dir=` is unknown.
+
+- [ ] **Step 4: Update `MetricWriter.__init__` signature and sink construction**
+
+In `tensoraerospace/agent/metrics/writer.py`, replace `MetricWriter.__init__` with:
+
+```python
+    def __init__(
+        self,
+        tb_log_dir: Optional[Union[str, Path]] = None,
+        *,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
+        strict: bool = True,
+        required: Iterable[str] = MANDATORY_METRICS,
+        algo: Optional[str] = None,
+    ) -> None:
+        self._sinks: list = []
+        if tb_log_dir is not None:
+            self._sinks.append(_TensorBoardSink(tb_log_dir))
+        if wandb_project is not None:
+            self._sinks.append(
+                _WandbSink(
+                    project=wandb_project,
+                    entity=wandb_entity,
+                    run_name=wandb_run_name,
+                    tags=wandb_tags,
+                    config=wandb_config,
+                )
+            )
+        self._strict = strict
+        self._required = tuple(required)
+        self._algo = algo
+        self._written: Set[str] = set()
+```
+
+Note: the auto-detection (env-var) logic lives in the **factory**, not in `MetricWriter.__init__` — `__init__` is explicit-only. Auto-detection is added in Task 5.
+
+- [ ] **Step 5: Run tests, expect PASS**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_writer_test.py -v
+```
+Expected: 14 PASSED (12 existing + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tensoraerospace/agent/metrics/writer.py tests/agents/metrics_writer_test.py
+git commit -m "feat(metrics): MetricWriter accepts wandb kwargs and builds sinks list
+
+Renames first positional kwarg log_dir -> tb_log_dir. Adds five wandb
+kwargs (project/entity/run_name/tags/config). When tb_log_dir or
+wandb_project is passed, the corresponding sink is added; otherwise the
+writer no-ops on logging while still enforcing the strict whitelist."
+```
+
+---
+
+## Task 5: Update `create_metric_writer` factory with auto-detection (TDD)
+
+**Files:**
+- Modify: `tensoraerospace/agent/metrics/writer.py`
+- Create: `tests/agents/metrics_factory_test.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/agents/metrics_factory_test.py`:
+
+```python
+"""Auto-activation behaviour of create_metric_writer."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensoraerospace.agent.metrics import writer as writer_mod
+from tensoraerospace.agent.metrics import (
+    MetricWriter,
+    create_metric_writer,
+    schema,
+)
+
+
+@pytest.fixture
+def mock_wandb(monkeypatch):
+    mock = MagicMock()
+    mock.init = MagicMock(return_value=MagicMock())
+    mock.Settings = MagicMock(return_value="S")
+    mock.Histogram = MagicMock(side_effect=lambda v: ("H", v))
+    monkeypatch.setattr(writer_mod, "wandb", mock, raising=False)
+    return mock
+
+
+def test_tb_only_when_only_tb_log_dir(tmp_path: Path, monkeypatch, mock_wandb):
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    w = create_metric_writer(tb_log_dir=str(tmp_path / "tb"), algo="sac")
+    assert len(w._sinks) == 1
+    mock_wandb.init.assert_not_called()
+
+
+def test_wandb_only_when_only_api_key(tmp_path: Path, monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    w = create_metric_writer(algo="sac")
+    assert len(w._sinks) == 1
+    mock_wandb.init.assert_called_once()
+    # default project is the algo
+    assert mock_wandb.init.call_args.kwargs["project"] == "sac"
+
+
+def test_both_when_tb_log_dir_and_api_key(tmp_path: Path, monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    w = create_metric_writer(tb_log_dir=str(tmp_path / "tb"), algo="ppo")
+    assert len(w._sinks) == 2
+    mock_wandb.init.assert_called_once()
+
+
+def test_zero_sinks_when_nothing(monkeypatch, mock_wandb):
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    w = create_metric_writer(algo="sac")
+    assert len(w._sinks) == 0
+    # whitelist still enforced
+    with pytest.raises(ValueError):
+        w.add_scalar("not/in/schema", 1.0, env_step=1)
+
+
+def test_explicit_wandb_project_calls_login_when_api_key_missing(
+    monkeypatch, mock_wandb
+):
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    create_metric_writer(wandb_project="my-exp", algo="sac")
+    mock_wandb.login.assert_called_once()
+    mock_wandb.init.assert_called_once()
+    assert mock_wandb.init.call_args.kwargs["project"] == "my-exp"
+
+
+def test_default_project_uses_algo_when_only_api_key(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer(algo="ddpg")
+    assert mock_wandb.init.call_args.kwargs["project"] == "ddpg"
+
+
+def test_default_project_falls_back_when_no_algo(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer()
+    assert mock_wandb.init.call_args.kwargs["project"] == "tensoraerospace"
+
+
+def test_default_run_name_includes_algo_and_timestamp(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer(algo="sac")
+    name = mock_wandb.init.call_args.kwargs["name"]
+    assert name.startswith("sac-")
+    assert len(name) > len("sac-")
+
+
+def test_default_tags_contain_algo(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer(algo="dqn")
+    tags = mock_wandb.init.call_args.kwargs["tags"]
+    assert "dqn" in tags
+
+
+def test_explicit_kwargs_override_defaults(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer(
+        algo="sac",
+        wandb_project="p",
+        wandb_entity="e",
+        wandb_run_name="r",
+        wandb_tags=["t1", "t2"],
+        wandb_config={"k": "v"},
+    )
+    kw = mock_wandb.init.call_args.kwargs
+    assert kw["project"] == "p"
+    assert kw["entity"] == "e"
+    assert kw["name"] == "r"
+    assert kw["tags"] == ["t1", "t2"]
+    assert kw["config"] == {"k": "v"}
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_factory_test.py -v
+```
+Expected: most fail (factory doesn't auto-detect yet).
+
+- [ ] **Step 3: Update `create_metric_writer` factory**
+
+In `tensoraerospace/agent/metrics/writer.py`, replace `create_metric_writer` with:
+
+```python
+import datetime as _dt
+
+
+def create_metric_writer(
+    tb_log_dir: Optional[Union[str, Path]] = None,
+    *,
+    wandb_project: Optional[str] = None,
+    wandb_entity: Optional[str] = None,
+    wandb_run_name: Optional[str] = None,
+    wandb_tags: Optional[Sequence[str]] = None,
+    wandb_config: Optional[Mapping[str, Any]] = None,
+    strict: bool = True,
+    algo: Optional[str] = None,
+) -> MetricWriter:
+    """Construct a MetricWriter with auto-detection of the wandb backend.
+
+    Activation rules:
+      * tb_log_dir set                          -> TB sink active.
+      * wandb_project set                       -> wandb sink active (calls
+                                                   wandb.login() if no key).
+      * WANDB_API_KEY in env, no wandb_project  -> wandb sink active with
+                                                   project = algo (or
+                                                   "tensoraerospace").
+
+    In multi-worker (forked) processes, wandb is skipped — see
+    docs/superpowers/specs/2026-04-20-wandb-backend-design.md.
+    """
+    import multiprocessing
+
+    is_main_process = multiprocessing.current_process().name == "MainProcess"
+
+    # Resolve wandb activation
+    wandb_enabled = is_main_process and (
+        wandb_project is not None or os.environ.get("WANDB_API_KEY") is not None
+    )
+
+    if wandb_enabled:
+        resolved_project = wandb_project or algo or "tensoraerospace"
+        if wandb_run_name is None:
+            ts = _dt.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+            wandb_run_name = f"{algo or 'run'}-{ts}"
+        if wandb_tags is None and algo is not None:
+            wandb_tags = [algo]
+    else:
+        resolved_project = None
+
+    return MetricWriter(
+        tb_log_dir=tb_log_dir,
+        wandb_project=resolved_project,
+        wandb_entity=wandb_entity,
+        wandb_run_name=wandb_run_name,
+        wandb_tags=wandb_tags,
+        wandb_config=wandb_config,
+        strict=strict,
+        algo=algo,
+    )
+```
+
+- [ ] **Step 4: Run tests, expect PASS**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_factory_test.py -v
+```
+Expected: 10 PASSED.
+
+- [ ] **Step 5: Run full metrics test suite (sanity)**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_*.py -v
+```
+Expected: 36 PASSED (existing 26 + new 10).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tensoraerospace/agent/metrics/writer.py tests/agents/metrics_factory_test.py
+git commit -m "feat(metrics): add wandb auto-detection to create_metric_writer
+
+WANDB_API_KEY in env auto-activates wandb sink (project = algo).
+wandb_project= forces wandb on regardless of env. Workers (non-main
+process) skip wandb. Default run name = algo + timestamp; default tags
+= [algo]."
+```
+
+---
+
+## Task 6: Add A3C parent-only behaviour test
+
+**Files:**
+- Create: `tests/agents/a3c_wandb_parent_only_test.py`
+
+The factory's parent-only logic was added in Task 5; this test pins that behaviour.
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/agents/a3c_wandb_parent_only_test.py`:
+
+```python
+"""Multi-worker guard: workers must not initialize wandb."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tensoraerospace.agent.metrics import create_metric_writer
+from tensoraerospace.agent.metrics import writer as writer_mod
+
+
+@pytest.fixture
+def mock_wandb(monkeypatch):
+    mock = MagicMock()
+    mock.init = MagicMock(return_value=MagicMock())
+    mock.Settings = MagicMock(return_value="S")
+    monkeypatch.setattr(writer_mod, "wandb", mock, raising=False)
+    return mock
+
+
+def test_in_main_process_wandb_init_runs(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    w = create_metric_writer(algo="a3c")
+    assert len(w._sinks) == 1
+    mock_wandb.init.assert_called_once()
+
+
+def test_in_worker_process_wandb_skipped(monkeypatch, mock_wandb):
+    """When not running as MainProcess, wandb sink is omitted."""
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+
+    fake_proc = MagicMock()
+    fake_proc.name = "Worker-1"
+    with patch("multiprocessing.current_process", return_value=fake_proc):
+        w = create_metric_writer(algo="a3c")
+
+    assert len(w._sinks) == 0
+    mock_wandb.init.assert_not_called()
+
+
+def test_in_worker_process_explicit_wandb_project_still_skipped(
+    monkeypatch, mock_wandb
+):
+    """Even an explicit wandb_project doesn't override the worker guard."""
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    fake_proc = MagicMock()
+    fake_proc.name = "Worker-2"
+    with patch("multiprocessing.current_process", return_value=fake_proc):
+        w = create_metric_writer(wandb_project="exp", algo="a3c")
+    assert len(w._sinks) == 0
+    mock_wandb.init.assert_not_called()
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+.venv/bin/python -m pytest tests/agents/a3c_wandb_parent_only_test.py -v
+```
+Expected: 3 PASSED.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/agents/a3c_wandb_parent_only_test.py
+git commit -m "test(metrics): pin parent-only wandb behaviour for A3C workers"
+```
+
+---
+
+## Task 7: Add dual-sink end-to-end smoke test
+
+**Files:**
+- Create: `tests/agents/metrics_dual_sink_smoke_test.py`
+
+- [ ] **Step 1: Write the test**
+
+Create `tests/agents/metrics_dual_sink_smoke_test.py`:
+
+```python
+"""Dual-sink end-to-end: SAC.train() writes to both TB and (mocked) wandb."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensoraerospace.agent.metrics import writer as writer_mod
+from tensoraerospace.agent.metrics import schema
+from tests.agents.metrics_contract_smoke_test import assert_tags_present
+
+
+REQUIRED = {
+    schema.ROLLOUT_EPISODE_REWARD,
+    schema.ROLLOUT_EPISODE_LENGTH,
+    schema.ROLLOUT_TOTAL_STEPS,
+    schema.TRAIN_UPDATES,
+    schema.TRAIN_LR,
+    schema.TRAIN_REPLAY_SIZE,
+    schema.SAC.LOSS_Q1,
+    schema.LOSS_POLICY,
+}
+
+
+@pytest.mark.timeout(120)
+def test_sac_writes_to_both_tb_and_wandb(tmp_path: Path, monkeypatch):
+    pytest.importorskip("torch")
+    pytest.importorskip("gymnasium")
+    pytest.importorskip("tensorboard")
+
+    import gymnasium as gym
+    from tensoraerospace.agent.sac.sac import SAC
+
+    # Mock wandb so the test doesn't hit the network
+    mock_wandb = MagicMock()
+    mock_wandb.init = MagicMock(return_value=MagicMock())
+    mock_wandb.Settings = MagicMock(return_value="S")
+    mock_wandb.Histogram = MagicMock(side_effect=lambda v: ("H", v))
+    monkeypatch.setattr(writer_mod, "wandb", mock_wandb, raising=False)
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+
+    env = gym.make("Pendulum-v1")
+    log_dir = tmp_path / "tb"
+
+    agent = SAC(
+        env=env,
+        batch_size=16,
+        memory_capacity=2_000,
+        log_dir=str(log_dir),
+        wandb_project="dual-sink-test",
+        device="cpu",
+    )
+    agent.train(num_episodes=1, max_steps=64, verbose=False)
+    agent.writer.flush()
+
+    # TB side: tags appear in event files
+    assert_tags_present(str(log_dir), REQUIRED)
+
+    # Wandb side: the same tags appear in mocked wandb.log calls
+    logged_keys = set()
+    for call in mock_wandb.log.call_args_list:
+        payload = call.args[0] if call.args else call.kwargs.get("data", {})
+        logged_keys.update(payload.keys())
+    missing = REQUIRED - logged_keys
+    assert not missing, (
+        f"Tags missing from wandb.log calls: {sorted(missing)}; "
+        f"got {sorted(logged_keys)}"
+    )
+```
+
+- [ ] **Step 2: Run the test, expect failure (SAC doesn't accept wandb_project yet)**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_dual_sink_smoke_test.py -v
+```
+Expected: TypeError on `wandb_project=` in `SAC(...)`.
+
+This will be fixed in Task 8 (when SAC ctor is extended). Leave the test as-is.
+
+- [ ] **Step 3: Commit the test (red state — it will go green after Task 8)**
+
+```bash
+git add tests/agents/metrics_dual_sink_smoke_test.py
+git commit -m "test(metrics): add dual-sink smoke test for SAC
+
+Currently red — turns green when SAC.__init__ gains wandb_project=
+in Task 8."
+```
+
+---
+
+## Task 8: Extend all 12 RL agent constructors with wandb kwargs
+
+**Files (modify):**
+- `tensoraerospace/agent/a2c/model.py`
+- `tensoraerospace/agent/a2c/narx.py`
+- `tensoraerospace/agent/a3c/pytorch.py`
+- `tensoraerospace/agent/adhdp/model.py`
+- `tensoraerospace/agent/adp/adp.py`
+- `tensoraerospace/agent/ddpg/model.py`
+- `tensoraerospace/agent/dqn/model.py` (both `DQNAgent` and `PERNARXAgent`)
+- `tensoraerospace/agent/dsac/dsac_flight.py`
+- `tensoraerospace/agent/et_dhp/model.py`
+- `tensoraerospace/agent/gail/model.py`
+- `tensoraerospace/agent/ppo/model.py`
+- `tensoraerospace/agent/sac/sac.py`
+
+The change pattern is identical for each: add five kwargs to `__init__`, store as instance attributes, forward to `create_metric_writer`. Apply mechanically to every file.
+
+- [ ] **Step 1: Add a typing import where missing**
+
+In each agent file, ensure these are importable:
+```python
+from typing import Any, Mapping, Optional, Sequence
+```
+(Most files already import some of these. Add only what's missing — do not duplicate.)
+
+- [ ] **Step 2: Add five kwargs to each agent's `__init__`**
+
+For every agent listed above, find the `__init__` signature and add these five keyword-only parameters at the end (or alongside the existing `log_dir` if any):
+
+```python
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
+```
+
+**Per-agent guidance for the `create_metric_writer` call site:**
+
+For each agent, find the existing call:
+```python
+self.writer = create_metric_writer(<positional log_dir>, algo="<name>")
+```
+(or `create_metric_writer(self.log_dir, algo="<name>")`).
+
+Replace with:
+```python
+self.writer = create_metric_writer(
+    tb_log_dir=<existing log_dir argument>,
+    wandb_project=wandb_project,
+    wandb_entity=wandb_entity,
+    wandb_run_name=wandb_run_name,
+    wandb_tags=wandb_tags,
+    wandb_config=wandb_config,
+    algo="<name>",
+)
+```
+
+**Specific files and call sites (verified):**
+
+- `tensoraerospace/agent/a2c/model.py:359` — `create_metric_writer(log_dir, algo="a2c")` → `create_metric_writer(tb_log_dir=log_dir, ...)`
+- `tensoraerospace/agent/a2c/narx.py:252` — `create_metric_writer(log_dir, algo="a2c-narx")` → forward kwargs
+- `tensoraerospace/agent/a3c/pytorch.py:499` — `create_metric_writer(log_dir, algo="a3c")` (inside `Agent.__init__`)
+- `tensoraerospace/agent/adhdp/model.py:453` — `create_metric_writer(self.log_dir, algo="adhdp")`
+- `tensoraerospace/agent/adp/adp.py:476` — `create_metric_writer(self.log_dir, algo="adp")`
+- `tensoraerospace/agent/ddpg/model.py:899` — `create_metric_writer(logdir, algo="ddpg")` (inside `learn()` lazy init; the kwargs need to come from `self.<wandb_*>` set in `__init__`)
+- `tensoraerospace/agent/dqn/model.py:292` (DQNAgent) and another at line 928 (PERNARXAgent) — both `create_metric_writer(self.log_dir, algo="dqn"|"dqn-narx")`
+- `tensoraerospace/agent/dsac/dsac_flight.py:131` — `create_metric_writer(self.log_dir, algo="dsac")`
+- `tensoraerospace/agent/et_dhp/model.py` — `create_metric_writer(self.log_dir, algo="etdhp")` (gated `if log_dir is not None`)
+- `tensoraerospace/agent/gail/model.py` — `create_metric_writer(self.log_dir, algo="gail")` (gated)
+- `tensoraerospace/agent/ppo/model.py` — `create_metric_writer(self.log_dir, algo="ppo")` (around line 622)
+- `tensoraerospace/agent/sac/sac.py:104` — `create_metric_writer(self.log_dir, algo="sac")`
+
+For each agent, the pattern after the change in `__init__`:
+```python
+self.wandb_project = wandb_project
+self.wandb_entity = wandb_entity
+self.wandb_run_name = wandb_run_name
+self.wandb_tags = wandb_tags
+self.wandb_config = wandb_config
+self.writer = create_metric_writer(
+    tb_log_dir=self.log_dir,  # or whatever local var holds the path
+    wandb_project=wandb_project,
+    wandb_entity=wandb_entity,
+    wandb_run_name=wandb_run_name,
+    wandb_tags=wandb_tags,
+    wandb_config=wandb_config,
+    algo="<name>",
+)
+```
+
+**Special cases:**
+
+- **ET-DHP / GAIL:** writer is gated `if log_dir is not None`. Change the gate to `if log_dir is not None or wandb_project is not None or os.environ.get("WANDB_API_KEY"):`. (Add `import os` if missing.)
+- **DDPG:** writer is lazily created inside `learn()`. Move the wandb kwargs into instance attrs in `__init__` (`self.wandb_project = wandb_project`, etc.), then in `learn()` use `self.wandb_project` etc. when constructing the writer.
+
+- [ ] **Step 3: Run the dual-sink smoke test (now expected to pass)**
+
+```bash
+.venv/bin/python -m pytest tests/agents/metrics_dual_sink_smoke_test.py -v
+```
+Expected: PASSED.
+
+- [ ] **Step 4: Run all 12 per-agent smoke tests (no regression)**
+
+```bash
+.venv/bin/python -m pytest tests/agents/*_metrics_smoke_test.py -v
+```
+Expected: 13 PASSED (12 existing + 1 dual-sink).
+
+- [ ] **Step 5: Run full agent suite**
+
+```bash
+.venv/bin/python -m pytest tests/agents/ --tb=short -q
+```
+Expected: previous count + new metrics tests (was 985; now ≈ 985 + 19 new metrics tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tensoraerospace/agent/
+git commit -m "feat(agents): forward wandb kwargs from agent ctor to create_metric_writer
+
+All 12 RL agents (A2C, A2C-NARX, A3C, ADHDP, ADP, DDPG, DQN x2, DSAC,
+ET-DHP, GAIL, PPO, SAC) now accept wandb_project/entity/run_name/tags/
+config in __init__ and forward them to the metrics factory.
+
+ET-DHP and GAIL gate writer construction on either log_dir or wandb
+activation. DDPG stores wandb kwargs as instance attrs because writer
+is lazily created in learn()."
+```
+
+---
+
+## Task 9: Update the metrics docs page
+
+**Files:**
+- Modify: `docs/en/guide/metrics.md`
+
+- [ ] **Step 1: Read the existing page**
+
+Run: `cat docs/en/guide/metrics.md | head -80`
+
+Identify the right place to insert a new section. A good location is right after the "Histogram convention" section, or as a top-level "Backends" section near the end, before "Adding a new algorithm".
+
+- [ ] **Step 2: Add a "Wandb backend" section**
+
+Append (or insert before "Adding a new algorithm"):
+
+```markdown
+## Wandb backend
+
+`MetricWriter` supports Weights & Biases as a second sink alongside
+TensorBoard. Both can be active at the same time — every `add_scalar` /
+`add_histogram` / `log_episode` call fans out to whichever sinks are
+enabled.
+
+### When wandb is enabled
+
+| `tb_log_dir` | `wandb_project` | `WANDB_API_KEY` | TB | wandb |
+|---|---|---|---|---|
+| set | — | — | ✅ | — |
+| set | — | set | ✅ | ✅ (project = `algo`) |
+| — | — | set | — | ✅ (project = `algo`) |
+| set | set | * | ✅ | ✅ (project as given) |
+| — | set | unset | — | ✅ (calls `wandb.login()` interactively) |
+| — | — | unset | — | — |
+
+### Example
+
+```python
+from tensoraerospace.agent.sac.sac import SAC
+
+# TensorBoard only (default)
+agent = SAC(env=env, log_dir="runs/sac")
+
+# Wandb only — set WANDB_API_KEY in env, then:
+agent = SAC(env=env, wandb_project="my-experiment", wandb_tags=["sac", "pendulum"])
+
+# Both backends in parallel
+agent = SAC(
+    env=env,
+    log_dir="runs/sac",
+    wandb_project="my-experiment",
+    wandb_config={"lr": 3e-4, "tau": 5e-3},
+)
+```
+
+### A3C limitation
+
+A3C runs workers in forked processes. The wandb sink is initialized only
+in the main process — workers continue to share the parent's TensorBoard
+event file via `/worker_<id>` suffix. To get per-worker wandb runs, use
+the launch-N-jobs pattern (one wandb run per worker process started
+externally) instead of `Agent.train()`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/en/guide/metrics.md
+git commit -m "docs: add Wandb backend section to metrics reference"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+.venv/bin/python -m pytest tests/ --tb=short
+```
+Expected: all tests pass (≈ 1724 + new metrics tests).
+
+- [ ] **Step 2: Verify no stragglers**
+
+Run: `grep -rn "log_dir=" tensoraerospace/agent/metrics/` should return no matches inside the metrics package (only `tb_log_dir=` remains).
+
+Run: `grep -rn "create_metric_writer(" tensoraerospace/agent/ --include="*.py"` should show every call site uses keyword args, not bare positional.
+
+- [ ] **Step 3: Manual smoke test against real wandb (optional, only if `WANDB_API_KEY` is available)**
+
+```bash
+export WANDB_API_KEY=<your-key>
+.venv/bin/python -c "
+import gymnasium as gym
+from tensoraerospace.agent.sac.sac import SAC
+
+env = gym.make('Pendulum-v1')
+agent = SAC(
+    env=env,
+    log_dir='runs/sac-wandb-manual',
+    wandb_project='tensoraero-smoke',
+    batch_size=16,
+    memory_capacity=2000,
+    device='cpu',
+)
+agent.train(num_episodes=1, max_steps=32, verbose=False)
+agent.writer.close()
+print('Run uploaded — check https://wandb.ai/<entity>/tensoraero-smoke')
+"
+```
+
+If a wandb key is not available, skip this step.
+
+- [ ] **Step 4: Final commit (if anything was fixed in Step 2/3)**
+
+```bash
+git status
+# if clean: nothing to do
+# else:
+git add -A
+git commit -m "chore: cleanup stragglers from wandb backend integration"
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+git push -u origin feature/wandb
+gh pr create --base develop --title "Add Wandb backend support for MetricWriter" --body "$(cat <<'EOF'
+## Summary
+
+Adds Weights & Biases as a second sink for `MetricWriter` alongside TensorBoard. Both can run in parallel.
+
+## How it activates
+
+- `WANDB_API_KEY` in env → wandb sink turns on automatically (project = `algo`).
+- `wandb_project=` kwarg → wandb sink turns on regardless; calls `wandb.login()` interactively if no key is set.
+- Per-agent kwargs: `wandb_project`, `wandb_entity`, `wandb_run_name`, `wandb_tags`, `wandb_config` on every RL agent's `__init__`.
+
+## Closes
+
+#176
+
+## Test plan
+
+- 6 new `_WandbSink` unit tests (mocked wandb).
+- 10 new factory auto-detection tests.
+- 3 new A3C parent-only tests.
+- 1 new dual-sink end-to-end smoke test.
+- All existing 985 agent tests continue to pass.
+EOF
+)"
+```
+
+---
+
+## Self-review (planner notes)
+
+**Spec coverage:** every requirement in `2026-04-20-wandb-backend-design.md` maps to a task:
+- Sink protocol → Tasks 2, 3
+- `create_metric_writer` auto-detection → Task 5
+- A3C parent-only → Task 5 (factory) + Task 6 (test)
+- 12-agent ctor extension → Task 8
+- `pyproject.toml` dep → Task 1
+- Documentation → Task 9
+- Tests (4 new files + 1 updated) → Tasks 3, 5, 6, 7
+
+**No placeholders.** All code blocks are complete; commands are exact.
+
+**Type consistency:** `_WandbSink.__init__` signature `(*, project, entity, run_name, tags, config)` matches what `MetricWriter.__init__` passes (Task 4) and what factory passes (Task 5). `MetricWriter.__init__` keyword names (`wandb_project`, `wandb_entity`, etc.) match the factory's kwargs (Task 5) match the agent ctors' kwargs (Task 8).

--- a/docs/superpowers/specs/2026-04-20-wandb-backend-design.md
+++ b/docs/superpowers/specs/2026-04-20-wandb-backend-design.md
@@ -1,0 +1,316 @@
+# Wandb Backend for MetricWriter — Design
+
+**Date:** 2026-04-20
+**Status:** Approved (brainstorming)
+**Scope:** Add Weights & Biases (`wandb`) as a second sink for `MetricWriter`, alongside the existing TensorBoard sink.
+**Related issue:** #176 (kept out of scope of #215; this spec closes it.)
+
+---
+
+## Problem
+
+The unified `MetricWriter` (introduced in #215) writes scalars, histograms,
+and episode summaries to TensorBoard event files via `SummaryWriter`. Many
+users want the same metrics in Weights & Biases at the same time — for
+team-shared experiment tracking and cross-run dashboards. Today there is no
+wandb integration; users would have to wrap every `add_scalar` call manually.
+
+## Goal
+
+Let any agent write metrics to wandb in addition to (or instead of)
+TensorBoard, with the same canonical schema, the same `env_step` X-axis,
+and the same strict-whitelist guarantees, by changing only the writer
+construction call.
+
+## Non-goals
+
+- Other backends (MLflow, CSV, console). The `_Sink` protocol leaves the
+  door open, but no implementations beyond TB and wandb in this spec.
+- Sweeps / hyperparameter optimization (orthogonal — wandb-sweep can
+  consume wandb runs without further work).
+- wandb Artifacts (model checkpoints). Out of scope; agent `save()` paths
+  remain unchanged.
+- Running wandb in *offline* mode by default. Users who need offline mode
+  set `WANDB_MODE=offline` themselves; we don't add a switch.
+
+---
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|---|---|
+| Strategy | Dual-sink. TB and wandb run in parallel; either may be off. |
+| Auto-detection | If `WANDB_API_KEY` is set in the environment, wandb-sink turns on automatically (and uses `algo` as the project name when none is supplied). |
+| Explicit override | Per-backend kwargs on `create_metric_writer(...)`: `tb_log_dir=...`, `wandb_project=...`, etc. Passing `tb_log_dir` forces TB on; passing `wandb_project` forces wandb on. |
+| Missing `WANDB_API_KEY` when wandb is requested | Call `wandb.login()` (interactive prompt). In CI, the wandb library itself raises a clear error. |
+| Wandb config surface | Basic set: `project, entity, run_name, tags, config` + `algo` (already exists). |
+| Architecture | `MetricWriter` as a façade with `0..N` private `_Sink` objects. Strict-whitelist validation stays in the façade — sinks never validate. |
+| A3C multi-worker | wandb-sink is parent-only. Workers (forked) skip wandb-init even if `WANDB_API_KEY` is set; they keep writing to the parent's TB writer (already shared via fork). |
+| Optional dep | `wandb` is added as a regular dependency in `pyproject.toml` (no `[wandb]` extra). Plain `ImportError` surfaces if it is somehow missing. |
+
+---
+
+## Architecture
+
+### Sink protocol
+
+```python
+class _Sink(Protocol):
+    def add_scalar(self, tag: str, value: float, env_step: int) -> None: ...
+    def add_histogram(self, tag: str, values, env_step: int) -> None: ...
+    def flush(self) -> None: ...
+    def close(self) -> None: ...
+```
+
+`MetricWriter` holds `self._sinks: list[_Sink]`. Each public method does:
+
+1. Strict-whitelist check (as today).
+2. Track in `self._written` (as today).
+3. Fan-out: `for sink in self._sinks: sink.<method>(...)`.
+
+The public surface of `MetricWriter` does not change in shape — only the
+constructor signature gains wandb kwargs and `log_dir` is renamed to
+`tb_log_dir` (with a positional-compat shim so existing call sites work).
+
+### Module layout
+
+```
+tensoraerospace/agent/metrics/
+├── __init__.py        # public re-exports (unchanged surface)
+├── schema.py          # unchanged
+├── contract.py        # unchanged
+├── writer.py          # MetricWriter façade + _TensorBoardSink + _WandbSink
+└── _sinks.py          # if writer.py grows past ~350 lines, split here
+```
+
+### MetricWriter constructor
+
+```python
+class MetricWriter:
+    def __init__(
+        self,
+        tb_log_dir: Optional[Union[str, Path]] = None,
+        *,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
+        strict: bool = True,
+        required: Iterable[str] = MANDATORY_METRICS,
+        algo: Optional[str] = None,
+    ) -> None:
+        ...
+```
+
+`create_metric_writer(...)` mirrors the same kwargs and is the agent-facing
+factory.
+
+### Auto-activation rules
+
+| `tb_log_dir` | `wandb_project` | `WANDB_API_KEY` | TB | wandb |
+|---|---|---|---|---|
+| set | — | — | ✅ | — |
+| set | — | set | ✅ | ✅ (project = `algo` or `"tensoraerospace"`) |
+| — | — | set | — | ✅ (project = `algo` or `"tensoraerospace"`) |
+| set | set | * | ✅ | ✅ (project as given) |
+| — | set | unset | — | ✅ (calls `wandb.login()` interactively) |
+| — | — | unset | — | — (writer is no-op) |
+
+### Default values when wandb-sink turns on
+
+- `wandb_run_name` → `f"{algo or 'run'}-{YYYY-MM-DD-HH-MM-SS}"`
+- `wandb_tags` → `[algo]` (extendable per agent)
+- `wandb_project` → `algo` if `WANDB_API_KEY` present and project not given
+- `wandb_config` → `None` (agents may pass their hyperparameters)
+
+---
+
+## `_WandbSink` behaviour
+
+```python
+class _WandbSink:
+    def __init__(self, *, project, entity, run_name, tags, config):
+        import wandb
+        self._wandb = wandb
+        if not os.environ.get("WANDB_API_KEY"):
+            wandb.login()  # interactive prompt
+        self._run = wandb.init(
+            project=project,
+            entity=entity,
+            name=run_name,
+            tags=list(tags) if tags else None,
+            config=dict(config) if config else None,
+            reinit=True,
+            settings=wandb.Settings(start_method="thread"),
+        )
+
+    def add_scalar(self, tag, value, env_step):
+        self._wandb.log({tag: float(value)}, step=int(env_step))
+
+    def add_histogram(self, tag, values, env_step):
+        self._wandb.log({tag: self._wandb.Histogram(values)}, step=int(env_step))
+
+    def flush(self):
+        pass  # wandb buffers internally
+
+    def close(self):
+        if self._run is not None:
+            self._run.finish()
+            self._run = None
+```
+
+Key technical notes:
+
+- **`reinit=True`** allows multiple `MetricWriter` instances per process
+  (e.g., notebook re-runs).
+- **`settings.start_method="thread"`** avoids fork-vs-grpc deadlocks under
+  `multiprocessing.fork()` (relevant for A3C).
+- **`flush()` is intentionally a no-op.** wandb maintains its own buffer
+  and flushes asynchronously; there is no public API to force a flush.
+- **Histogram**: any numpy/torch tensor passed through `wandb.Histogram(...)`.
+- **Step axis**: every `wandb.log(...)` call passes `step=env_step`, so
+  charts share the X-axis with TB.
+
+---
+
+## Multi-worker A3C handling
+
+Wandb runs do not survive `fork()`: the gRPC channel and uploader thread
+hold parent-process state that does not transfer to children. Calling
+`wandb.init()` from each worker would either crash or create separate
+spurious runs.
+
+**Rule:** `_WandbSink.__init__` runs only in the main process. In a worker
+process (detected via `multiprocessing.current_process().name != "MainProcess"`,
+or explicitly via a `_skip_wandb_init` agent-level flag), `create_metric_writer`
+constructs the writer with the wandb-sink **omitted** even if the env var is
+set.
+
+A3C workers continue writing to the parent's TB-sink (already shared via
+fork file-descriptor inheritance) under the `/worker_<id>` suffix
+convention.
+
+---
+
+## Migration impact
+
+### `MetricWriter` / `create_metric_writer`
+
+- Rename first positional kwarg `log_dir` → `tb_log_dir`. Both the class
+  and the factory keep it as the first positional, so existing
+  `create_metric_writer("runs/sac", algo="sac")` calls continue to work.
+- Add the five wandb kwargs.
+- Add the env-var auto-detection block at top of factory.
+- All existing `MetricWriter(log_dir=...)` keyword call sites in tests get
+  renamed to `tb_log_dir=...` (search-and-replace).
+
+### Each of the 12 RL agents
+
+Add five wandb kwargs to `__init__` (existing `log_dir` stays):
+
+```python
+def __init__(
+    self,
+    ...,
+    log_dir: Optional[str] = None,
+    wandb_project: Optional[str] = None,
+    wandb_entity: Optional[str] = None,
+    wandb_run_name: Optional[str] = None,
+    wandb_tags: Optional[Sequence[str]] = None,
+    wandb_config: Optional[Mapping[str, Any]] = None,
+):
+    ...
+    self.writer = create_metric_writer(
+        tb_log_dir=log_dir,
+        wandb_project=wandb_project,
+        wandb_entity=wandb_entity,
+        wandb_run_name=wandb_run_name,
+        wandb_tags=wandb_tags,
+        wandb_config=wandb_config,
+        algo="<agent>",
+    )
+```
+
+For agents whose ctor does not accept `log_dir` today (A2C — added in
+#215), add the same block. ET-DHP and GAIL already accept `log_dir`; same
+treatment.
+
+### `pyproject.toml`
+
+Add `wandb` to `[tool.poetry.dependencies]` (or whatever dependency table
+the project uses). Pin to a recent stable major (e.g., `^0.18` or `^0.19`).
+
+---
+
+## Testing strategy
+
+1. **Existing schema/writer unit tests** (`metrics_schema_test.py`,
+   `metrics_writer_test.py`) — update to the renamed `tb_log_dir` kwarg;
+   no semantic change in coverage.
+
+2. **`tests/agents/metrics_wandb_sink_test.py`** — patch
+   `tensoraerospace.agent.metrics.writer.wandb`:
+   - `add_scalar` triggers `wandb.log({tag: value}, step=env_step)` exactly once.
+   - `add_histogram` wraps values via `wandb.Histogram`.
+   - `__init__` calls `wandb.login()` iff `WANDB_API_KEY` is unset.
+   - `__init__` calls `wandb.init(...)` with the right kwargs (project,
+     entity, run name, tags, config, reinit, settings).
+   - `close()` calls `_run.finish()`.
+   - Reading `_WandbSink` after `close()` is a no-op (no double-finish).
+
+3. **`tests/agents/metrics_factory_test.py`** — the auto-activation
+   table:
+   - `tb_log_dir=...` only → 1 sink, type `_TensorBoardSink`.
+   - `WANDB_API_KEY` only → 1 sink, type `_WandbSink`, project = algo.
+   - both → 2 sinks.
+   - nothing → 0 sinks; `add_scalar` whitelist still enforced; no error.
+   - `wandb_project=` without `WANDB_API_KEY` → `wandb.login()` called.
+
+4. **`tests/agents/metrics_dual_sink_smoke_test.py`** — runs SAC for 1
+   episode with both sinks active (wandb mocked); asserts the TB event
+   file contains canonical tags AND the mocked `wandb.log(...)` was
+   called with the same set of canonical tags.
+
+5. **`tests/agents/a3c_wandb_parent_only_test.py`** — mock
+   `multiprocessing.current_process().name` to a child name; assert that
+   `create_metric_writer(wandb_project=...)` returns a writer with
+   `_WandbSink` **omitted** from `_sinks`.
+
+6. **All 12 existing per-agent smoke tests** (`*_metrics_smoke_test.py`)
+   continue to pass with no edits — default test environment has no
+   `WANDB_API_KEY`, so behaviour is identical to today.
+
+---
+
+## Out of scope (explicitly)
+
+- Wandb Sweeps integration.
+- Wandb Artifacts (model uploads).
+- Offline-mode toggle (users set `WANDB_MODE=offline` themselves).
+- MLflow / CSV / console sinks (the `_Sink` protocol allows them later).
+- Custom wandb panels / charts pre-configured per algo.
+
+---
+
+## Acceptance criteria
+
+1. `create_metric_writer(tb_log_dir="runs/sac")` behaves exactly as today
+   when `WANDB_API_KEY` is unset (no wandb dependency exercised, no extra
+   network calls).
+2. With `WANDB_API_KEY` set, the same call additionally creates an
+   active wandb run with project = `algo`.
+3. `create_metric_writer(tb_log_dir="runs/sac", wandb_project="exp1")`
+   creates two sinks regardless of env var; missing `WANDB_API_KEY`
+   triggers `wandb.login()`.
+4. `MetricWriter.add_scalar(schema.LOSS_ACTOR, 0.5, env_step=10)` results
+   in (a) a TB event file entry AND (b) a `wandb.log(...)` call when
+   both sinks are active.
+5. A3C training does not call `wandb.init()` from worker processes.
+6. All 12 RL agents accept the five wandb kwargs in their `__init__` and
+   forward them to `create_metric_writer(...)`.
+7. New unit-test files (4) and updated existing tests pass; full
+   `pytest tests/` continues to pass (currently 1724 / 0).
+8. Documentation page `docs/en/guide/metrics.md` gains a new section
+   "Wandb backend" covering: enabling, env-var auto-detect, kwargs,
+   A3C limitation.

--- a/poetry.lock
+++ b/poetry.lock
@@ -635,7 +635,6 @@ files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
 ]
-markers = {main = "extra == \"ray\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -1157,6 +1156,21 @@ files = [
 ]
 
 [[package]]
+name = "docker-pycreds"
+version = "0.4.0"
+description = "Python bindings for the docker credentials store API"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "docker-pycreds-0.4.0.tar.gz", hash = "sha256:6ce3270bcaf404cc4c3e27e4b6c70d3521deae82fb508767870fdbf772d584d4"},
+    {file = "docker_pycreds-0.4.0-py2.py3-none-any.whl", hash = "sha256:7266112468627868005106ec19cd0d722702d2b7d5912a28e19b826c3d37af49"},
+]
+
+[package.dependencies]
+six = ">=1.4.0"
+
+[[package]]
 name = "docstr-coverage"
 version = "2.3.2"
 description = "Utility for examining python source files to ensure proper documentation. Lists missing docstrings, and calculates overall docstring coverage percentage rating."
@@ -1466,6 +1480,40 @@ python-dateutil = ">=2.8.1"
 
 [package.extras]
 dev = ["flake8", "markdown", "twine", "wheel"]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+description = "Git Object Database"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf"},
+    {file = "gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571"},
+]
+
+[package.dependencies]
+smmap = ">=3.0.1,<6"
+
+[[package]]
+name = "gitpython"
+version = "3.1.46"
+description = "GitPython is a Python library used to interact with Git repositories"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "gitpython-3.1.46-py3-none-any.whl", hash = "sha256:79812ed143d9d25b6d176a10bb511de0f9c67b1fa641d82097b0ab90398a2058"},
+    {file = "gitpython-3.1.46.tar.gz", hash = "sha256:400124c7d0ef4ea03f7310ac2fbf7151e09ff97f2a3288d64a440c584a29c37f"},
+]
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[package.extras]
+doc = ["sphinx (>=7.1.2,<7.2)", "sphinx-autodoc-typehints", "sphinx_rtd_theme"]
+test = ["coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock ; python_version < \"3.8\"", "mypy (==1.18.2) ; python_version >= \"3.9\"", "pre-commit", "pytest (>=7.3.1)", "pytest-cov", "pytest-instafail", "pytest-mock", "pytest-sugar", "typing-extensions ; python_version < \"3.11\""]
 
 [[package]]
 name = "greenlet"
@@ -4126,7 +4174,7 @@ version = "4.4.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "jupyter"]
+groups = ["main", "dev", "jupyter"]
 files = [
     {file = "platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85"},
     {file = "platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf"},
@@ -4224,21 +4272,23 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "7.34.1"
+version = "5.29.6"
 description = ""
-optional = true
-python-versions = ">=3.10"
+optional = false
+python-versions = ">=3.8"
 groups = ["main"]
-markers = "extra == \"ray\""
 files = [
-    {file = "protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7"},
-    {file = "protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b"},
-    {file = "protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a"},
-    {file = "protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4"},
-    {file = "protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a"},
-    {file = "protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c"},
-    {file = "protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11"},
-    {file = "protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280"},
+    {file = "protobuf-5.29.6-cp310-abi3-win32.whl", hash = "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1"},
+    {file = "protobuf-5.29.6-cp310-abi3-win_amd64.whl", hash = "sha256:7e6ad413275be172f67fdee0f43484b6de5a904cc1c3ea9804cb6fe2ff366eda"},
+    {file = "protobuf-5.29.6-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:b5a169e664b4057183a34bdc424540e86eea47560f3c123a0d64de4e137f9269"},
+    {file = "protobuf-5.29.6-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:a8866b2cff111f0f863c1b3b9e7572dc7eaea23a7fae27f6fc613304046483e6"},
+    {file = "protobuf-5.29.6-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:e3387f44798ac1106af0233c04fb8abf543772ff241169946f698b3a9a3d3ab9"},
+    {file = "protobuf-5.29.6-cp38-cp38-win32.whl", hash = "sha256:36ade6ff88212e91aef4e687a971a11d7d24d6948a66751abc1b3238648f5d05"},
+    {file = "protobuf-5.29.6-cp38-cp38-win_amd64.whl", hash = "sha256:831e2da16b6cc9d8f1654c041dd594eda43391affd3c03a91bea7f7f6da106d6"},
+    {file = "protobuf-5.29.6-cp39-cp39-win32.whl", hash = "sha256:cb4c86de9cd8a7f3a256b9744220d87b847371c6b2f10bde87768918ef33ba49"},
+    {file = "protobuf-5.29.6-cp39-cp39-win_amd64.whl", hash = "sha256:76e07e6567f8baf827137e8d5b8204b6c7b6488bbbff1bf0a72b383f77999c18"},
+    {file = "protobuf-5.29.6-py3-none-any.whl", hash = "sha256:6b9edb641441b2da9fa8f428760fc136a49cf97a52076010cf22a2ff73438a86"},
+    {file = "protobuf-5.29.6.tar.gz", hash = "sha256:da9ee6a5424b6b30fd5e45c5ea663aef540ca95f9ad99d1e887e819cdf9b8723"},
 ]
 
 [[package]]
@@ -4247,7 +4297,7 @@ version = "7.1.0"
 description = "Cross-platform lib for process and system monitoring."
 optional = false
 python-versions = ">=3.6"
-groups = ["dev", "jupyter"]
+groups = ["main", "dev", "jupyter"]
 files = [
     {file = "psutil-7.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76168cef4397494250e9f4e73eb3752b146de1dd950040b29186d0cce1d5ca13"},
     {file = "psutil-7.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:5d007560c8c372efdff9e4579c2846d71de737e4605f611437255e81efcca2c5"},
@@ -5887,6 +5937,180 @@ objc = ["pyobjc-framework-Cocoa ; sys_platform == \"darwin\""]
 win32 = ["pywin32 ; sys_platform == \"win32\""]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+description = "Python client for Sentry (https://sentry.io)"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e"},
+    {file = "sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f"},
+]
+
+[package.dependencies]
+certifi = "*"
+urllib3 = ">=1.26.11"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.5)"]
+anthropic = ["anthropic (>=0.16)"]
+arq = ["arq (>=0.23)"]
+asyncio = ["httpcore[asyncio] (==1.*)"]
+asyncpg = ["asyncpg (>=0.23)"]
+beam = ["apache-beam (>=2.12)"]
+bottle = ["bottle (>=0.12.13)"]
+celery = ["celery (>=3)"]
+celery-redbeat = ["celery-redbeat (>=2)"]
+chalice = ["chalice (>=1.16.0)"]
+clickhouse-driver = ["clickhouse-driver (>=0.2.0)"]
+django = ["django (>=1.8)"]
+falcon = ["falcon (>=1.4)"]
+fastapi = ["fastapi (>=0.79.0)"]
+flask = ["blinker (>=1.1)", "flask (>=0.11)", "markupsafe"]
+google-genai = ["google-genai (>=1.29.0)"]
+grpcio = ["grpcio (>=1.21.1)", "protobuf (>=3.8.0)"]
+http2 = ["httpcore[http2] (==1.*)"]
+httpx = ["httpx (>=0.16.0)"]
+huey = ["huey (>=2)"]
+huggingface-hub = ["huggingface_hub (>=0.22)"]
+langchain = ["langchain (>=0.0.210)"]
+langgraph = ["langgraph (>=0.6.6)"]
+launchdarkly = ["launchdarkly-server-sdk (>=9.8.0)"]
+litellm = ["litellm (>=1.77.5,!=1.82.7,!=1.82.8)"]
+litestar = ["litestar (>=2.0.0)"]
+loguru = ["loguru (>=0.5)"]
+mcp = ["mcp (>=1.15.0)"]
+openai = ["openai (>=1.0.0)", "tiktoken (>=0.3.0)"]
+openfeature = ["openfeature-sdk (>=0.7.1)"]
+opentelemetry = ["opentelemetry-distro (>=0.35b0)"]
+opentelemetry-experimental = ["opentelemetry-distro"]
+opentelemetry-otlp = ["opentelemetry-distro[otlp] (>=0.35b0)"]
+pure-eval = ["asttokens", "executing", "pure_eval"]
+pydantic-ai = ["pydantic-ai (>=1.0.0)"]
+pymongo = ["pymongo (>=3.1)"]
+pyspark = ["pyspark (>=2.4.4)"]
+quart = ["blinker (>=1.1)", "quart (>=0.16.1)"]
+rq = ["rq (>=0.6)"]
+sanic = ["sanic (>=0.8)"]
+sqlalchemy = ["sqlalchemy (>=1.2)"]
+starlette = ["starlette (>=0.19.1)"]
+starlite = ["starlite (>=1.48)"]
+statsig = ["statsig (>=0.55.3)"]
+tornado = ["tornado (>=6)"]
+unleash = ["UnleashClient (>=6.0.1)"]
+
+[[package]]
+name = "setproctitle"
+version = "1.3.7"
+description = "A Python module to customize the process title"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "setproctitle-1.3.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cf555b6299f10a6eb44e4f96d2f5a3884c70ce25dc5c8796aaa2f7b40e72cb1b"},
+    {file = "setproctitle-1.3.7-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:690b4776f9c15aaf1023bb07d7c5b797681a17af98a4a69e76a1d504e41108b7"},
+    {file = "setproctitle-1.3.7-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:00afa6fc507967d8c9d592a887cdc6c1f5742ceac6a4354d111ca0214847732c"},
+    {file = "setproctitle-1.3.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9e02667f6b9fc1238ba753c0f4b0a37ae184ce8f3bbbc38e115d99646b3f4cd3"},
+    {file = "setproctitle-1.3.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:83fcd271567d133eb9532d3b067c8a75be175b2b3b271e2812921a05303a693f"},
+    {file = "setproctitle-1.3.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:13fe37951dda1a45c35d77d06e3da5d90e4f875c4918a7312b3b4556cfa7ff64"},
+    {file = "setproctitle-1.3.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a05509cfb2059e5d2ddff701d38e474169e9ce2a298cf1b6fd5f3a213a553fe5"},
+    {file = "setproctitle-1.3.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6da835e76ae18574859224a75db6e15c4c2aaa66d300a57efeaa4c97ca4c7381"},
+    {file = "setproctitle-1.3.7-cp310-cp310-win32.whl", hash = "sha256:9e803d1b1e20240a93bac0bc1025363f7f80cb7eab67dfe21efc0686cc59ad7c"},
+    {file = "setproctitle-1.3.7-cp310-cp310-win_amd64.whl", hash = "sha256:a97200acc6b64ec4cada52c2ecaf1fba1ef9429ce9c542f8a7db5bcaa9dcbd95"},
+    {file = "setproctitle-1.3.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a600eeb4145fb0ee6c287cb82a2884bd4ec5bbb076921e287039dcc7b7cc6dd0"},
+    {file = "setproctitle-1.3.7-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97a090fed480471bb175689859532709e28c085087e344bca45cf318034f70c4"},
+    {file = "setproctitle-1.3.7-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1607b963e7b53e24ec8a2cb4e0ab3ae591d7c6bf0a160feef0551da63452b37f"},
+    {file = "setproctitle-1.3.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a20fb1a3974e2dab857870cf874b325b8705605cb7e7e8bcbb915bca896f52a9"},
+    {file = "setproctitle-1.3.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8d961bba676e07d77665204f36cffaa260f526e7b32d07ab3df6a2c1dfb44ba"},
+    {file = "setproctitle-1.3.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:db0fd964fbd3a9f8999b502f65bd2e20883fdb5b1fae3a424e66db9a793ed307"},
+    {file = "setproctitle-1.3.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:db116850fcf7cca19492030f8d3b4b6e231278e8fe097a043957d22ce1bdf3ee"},
+    {file = "setproctitle-1.3.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:316664d8b24a5c91ee244460bdaf7a74a707adaa9e14fbe0dc0a53168bb9aba1"},
+    {file = "setproctitle-1.3.7-cp311-cp311-win32.whl", hash = "sha256:b74774ca471c86c09b9d5037c8451fff06bb82cd320d26ae5a01c758088c0d5d"},
+    {file = "setproctitle-1.3.7-cp311-cp311-win_amd64.whl", hash = "sha256:acb9097213a8dd3410ed9f0dc147840e45ca9797785272928d4be3f0e69e3be4"},
+    {file = "setproctitle-1.3.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2dc99aec591ab6126e636b11035a70991bc1ab7a261da428491a40b84376654e"},
+    {file = "setproctitle-1.3.7-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdd8aa571b7aa39840fdbea620e308a19691ff595c3a10231e9ee830339dd798"},
+    {file = "setproctitle-1.3.7-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2906b6c7959cdb75f46159bf0acd8cc9906cf1361c9e1ded0d065fe8f9039629"},
+    {file = "setproctitle-1.3.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6915964a6dda07920a1159321dcd6d94fc7fc526f815ca08a8063aeca3c204f1"},
+    {file = "setproctitle-1.3.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cff72899861c765bd4021d1ff1c68d60edc129711a2fdba77f9cb69ef726a8b6"},
+    {file = "setproctitle-1.3.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7cb05bd446687ff816a3aaaf831047fc4c364feff7ada94a66024f1367b448c"},
+    {file = "setproctitle-1.3.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:3a57b9a00de8cae7e2a1f7b9f0c2ac7b69372159e16a7708aa2f38f9e5cc987a"},
+    {file = "setproctitle-1.3.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d8828b356114f6b308b04afe398ed93803d7fca4a955dd3abe84430e28d33739"},
+    {file = "setproctitle-1.3.7-cp312-cp312-win32.whl", hash = "sha256:b0304f905efc845829ac2bc791ddebb976db2885f6171f4a3de678d7ee3f7c9f"},
+    {file = "setproctitle-1.3.7-cp312-cp312-win_amd64.whl", hash = "sha256:9888ceb4faea3116cf02a920ff00bfbc8cc899743e4b4ac914b03625bdc3c300"},
+    {file = "setproctitle-1.3.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3736b2a423146b5e62230502e47e08e68282ff3b69bcfe08a322bee73407922"},
+    {file = "setproctitle-1.3.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3384e682b158d569e85a51cfbde2afd1ab57ecf93ea6651fe198d0ba451196ee"},
+    {file = "setproctitle-1.3.7-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0564a936ea687cd24dffcea35903e2a20962aa6ac20e61dd3a207652401492dd"},
+    {file = "setproctitle-1.3.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5d1cb3f81531f0eb40e13246b679a1bdb58762b170303463cb06ecc296f26d0"},
+    {file = "setproctitle-1.3.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a7d159e7345f343b44330cbba9194169b8590cb13dae940da47aa36a72aa9929"},
+    {file = "setproctitle-1.3.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0b5074649797fd07c72ca1f6bff0406f4a42e1194faac03ecaab765ce605866f"},
+    {file = "setproctitle-1.3.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:61e96febced3f61b766115381d97a21a6265a0f29188a791f6df7ed777aef698"},
+    {file = "setproctitle-1.3.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:047138279f9463f06b858e579cc79580fbf7a04554d24e6bddf8fe5dddbe3d4c"},
+    {file = "setproctitle-1.3.7-cp313-cp313-win32.whl", hash = "sha256:7f47accafac7fe6535ba8ba9efd59df9d84a6214565108d0ebb1199119c9cbbd"},
+    {file = "setproctitle-1.3.7-cp313-cp313-win_amd64.whl", hash = "sha256:fe5ca35aeec6dc50cabab9bf2d12fbc9067eede7ff4fe92b8f5b99d92e21263f"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:10e92915c4b3086b1586933a36faf4f92f903c5554f3c34102d18c7d3f5378e9"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:de879e9c2eab637f34b1a14c4da1e030c12658cdc69ee1b3e5be81b380163ce5"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c18246d88e227a5b16248687514f95642505000442165f4b7db354d39d0e4c29"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7081f193dab22df2c36f9fc6d113f3793f83c27891af8fe30c64d89d9a37e152"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cc9b901ce129350637426a89cfd650066a4adc6899e47822e2478a74023ff7c"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:80e177eff2d1ec172188d0d7fd9694f8e43d3aab76a6f5f929bee7bf7894e98b"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:23e520776c445478a67ee71b2a3c1ffdafbe1f9f677239e03d7e2cc635954e18"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:5fa1953126a3b9bd47049d58c51b9dac72e78ed120459bd3aceb1bacee72357c"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-win32.whl", hash = "sha256:4a5e212bf438a4dbeece763f4962ad472c6008ff6702e230b4f16a037e2f6f29"},
+    {file = "setproctitle-1.3.7-cp313-cp313t-win_amd64.whl", hash = "sha256:cf2727b733e90b4f874bac53e3092aa0413fe1ea6d4f153f01207e6ce65034d9"},
+    {file = "setproctitle-1.3.7-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:80c36c6a87ff72eabf621d0c79b66f3bdd0ecc79e873c1e9f0651ee8bf215c63"},
+    {file = "setproctitle-1.3.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b53602371a52b91c80aaf578b5ada29d311d12b8a69c0c17fbc35b76a1fd4f2e"},
+    {file = "setproctitle-1.3.7-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fcb966a6c57cf07cc9448321a08f3be6b11b7635be502669bc1d8745115d7e7f"},
+    {file = "setproctitle-1.3.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46178672599b940368d769474fe13ecef1b587d58bb438ea72b9987f74c56ea5"},
+    {file = "setproctitle-1.3.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7f9e9e3ff135cbcc3edd2f4cf29b139f4aca040d931573102742db70ff428c17"},
+    {file = "setproctitle-1.3.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:14c7eba8d90c93b0e79c01f0bd92a37b61983c27d6d7d5a3b5defd599113d60e"},
+    {file = "setproctitle-1.3.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9e64e98077fb30b6cf98073d6c439cd91deb8ebbf8fc62d9dbf52bd38b0c6ac0"},
+    {file = "setproctitle-1.3.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b91387cc0f02a00ac95dcd93f066242d3cca10ff9e6153de7ee07069c6f0f7c8"},
+    {file = "setproctitle-1.3.7-cp314-cp314-win32.whl", hash = "sha256:52b054a61c99d1b72fba58b7f5486e04b20fefc6961cd76722b424c187f362ed"},
+    {file = "setproctitle-1.3.7-cp314-cp314-win_amd64.whl", hash = "sha256:5818e4080ac04da1851b3ec71e8a0f64e3748bf9849045180566d8b736702416"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:6fc87caf9e323ac426910306c3e5d3205cd9f8dcac06d233fcafe9337f0928a3"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6134c63853d87a4897ba7d5cc0e16abfa687f6c66fc09f262bb70d67718f2309"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1403d2abfd32790b6369916e2313dffbe87d6b11dca5bbd898981bcde48e7a2b"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e7c5bfe4228ea22373e3025965d1a4116097e555ee3436044f5c954a5e63ac45"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:585edf25e54e21a94ccb0fe81ad32b9196b69ebc4fc25f81da81fb8a50cca9e4"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:96c38cdeef9036eb2724c2210e8d0b93224e709af68c435d46a4733a3675fee1"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:45e3ef48350abb49cf937d0a8ba15e42cee1e5ae13ca41a77c66d1abc27a5070"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1fae595d032b30dab4d659bece20debd202229fce12b55abab978b7f30783d73"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-win32.whl", hash = "sha256:02432f26f5d1329ab22279ff863c83589894977063f59e6c4b4845804a08f8c2"},
+    {file = "setproctitle-1.3.7-cp314-cp314t-win_amd64.whl", hash = "sha256:cbc388e3d86da1f766d8fc2e12682e446064c01cea9f88a88647cfe7c011de6a"},
+    {file = "setproctitle-1.3.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:376761125ab5dab822d40eaa7d9b7e876627ecd41de8fa5336713b611b47ccef"},
+    {file = "setproctitle-1.3.7-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2a4e03bd9aa5d10b8702f00ec1b740691da96b5003432f3000d60c56f1c2b4d3"},
+    {file = "setproctitle-1.3.7-cp38-cp38-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:47d36e418ab86b3bc7946e27155e281a743274d02cd7e545f5d628a2875d32f9"},
+    {file = "setproctitle-1.3.7-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a74714ce836914063c36c8a26ae11383cf8a379698c989fe46883e38a8faa5be"},
+    {file = "setproctitle-1.3.7-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f2ae6c3f042fc866cc0fa2bc35ae00d334a9fa56c9d28dfc47d1b4f5ed23e375"},
+    {file = "setproctitle-1.3.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:be7e01f3ad8d0e43954bebdb3088cb466633c2f4acdd88647e7fbfcfe9b9729f"},
+    {file = "setproctitle-1.3.7-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:35a2cabcfdea4643d7811cfe9f3d92366d282b38ef5e7e93e25dafb6f97b0a59"},
+    {file = "setproctitle-1.3.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:8ce2e39a40fca82744883834683d833e0eb28623752cc1c21c2ec8f06a890b39"},
+    {file = "setproctitle-1.3.7-cp38-cp38-win32.whl", hash = "sha256:6f1be447456fe1e16c92f5fb479404a850d8f4f4ff47192fde14a59b0bae6a0a"},
+    {file = "setproctitle-1.3.7-cp38-cp38-win_amd64.whl", hash = "sha256:5ce2613e1361959bff81317dc30a60adb29d8132b6159608a783878fc4bc4bbc"},
+    {file = "setproctitle-1.3.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:deda9d79d1eb37b688729cac2dba0c137e992ebea960eadb7c2c255524c869e0"},
+    {file = "setproctitle-1.3.7-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a93e4770ac22794cfa651ee53f092d7de7105c76b9fc088bb81ca0dcf698f704"},
+    {file = "setproctitle-1.3.7-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:134e7f66703a1d92c0a9a0a417c580f2cc04b93d31d3fc0dd43c3aa194b706e1"},
+    {file = "setproctitle-1.3.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9796732a040f617fc933f9531c9a84bb73c5c27b8074abbe52907076e804b2b7"},
+    {file = "setproctitle-1.3.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ff3c1c32382fb71a200db8bab3df22f32e6ac7ec3170e92fa5b542cf42eed9a2"},
+    {file = "setproctitle-1.3.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:01f27b5b72505b304152cb0bd7ff410cc4f2d69ac70c21a7fdfa64400a68642d"},
+    {file = "setproctitle-1.3.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:80b6a562cbc92b289c28f34ce709a16b26b1696e9b9a0542a675ce3a788bdf3f"},
+    {file = "setproctitle-1.3.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c4fb90174d176473122e7eef7c6492d53761826f34ff61c81a1c1d66905025d3"},
+    {file = "setproctitle-1.3.7-cp39-cp39-win32.whl", hash = "sha256:c77b3f58a35f20363f6e0a1219b367fbf7e2d2efe3d2c32e1f796447e6061c10"},
+    {file = "setproctitle-1.3.7-cp39-cp39-win_amd64.whl", hash = "sha256:318ddcf88dafddf33039ad41bc933e1c49b4cb196fe1731a209b753909591680"},
+    {file = "setproctitle-1.3.7-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:eb440c5644a448e6203935ed60466ec8d0df7278cd22dc6cf782d07911bcbea6"},
+    {file = "setproctitle-1.3.7-pp310-pypy310_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:502b902a0e4c69031b87870ff4986c290ebbb12d6038a70639f09c331b18efb2"},
+    {file = "setproctitle-1.3.7-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:f6f268caeabb37ccd824d749e7ce0ec6337c4ed954adba33ec0d90cc46b0ab78"},
+    {file = "setproctitle-1.3.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1cac6a4b0252b8811d60b6d8d0f157c0fdfed379ac89c25a914e6346cf355a1"},
+    {file = "setproctitle-1.3.7-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f1704c9e041f2b1dc38f5be4552e141e1432fba3dd52c72eeffd5bc2db04dc65"},
+    {file = "setproctitle-1.3.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:b08b61976ffa548bd5349ce54404bf6b2d51bd74d4f1b241ed1b0f25bce09c3a"},
+    {file = "setproctitle-1.3.7.tar.gz", hash = "sha256:bc2bc917691c1537d5b9bca1468437176809c7e11e5694ca79a9ca12345dcb9e"},
+]
+
+[package.extras]
+test = ["pytest"]
+
+[[package]]
 name = "setuptools"
 version = "80.9.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -5929,6 +6153,18 @@ groups = ["main", "dev", "jupyter"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+description = "A pure Python implementation of a sliding window memory map manager"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f"},
+    {file = "smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c"},
 ]
 
 [[package]]
@@ -6515,6 +6751,53 @@ socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
+name = "wandb"
+version = "0.18.7"
+description = "A CLI and library for interacting with the Weights & Biases API."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "wandb-0.18.7-py3-none-any.whl", hash = "sha256:c2b9f9fea6daf8b62a505ea5d77d7e5e375c6014947a8882c0497399a9a1e4af"},
+    {file = "wandb-0.18.7-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:9fb2d381b20a079d7bb519b1b5cbbd94a10e941a2a0c5ccc044748b00344a294"},
+    {file = "wandb-0.18.7-py3-none-macosx_11_0_arm64.whl", hash = "sha256:87209f5aed8dbcf4b699ce745d096bc13b3cb66217efa5c44dd772d4f7fe7836"},
+    {file = "wandb-0.18.7-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:e31d2115c558257406bf9beffe13d42313d958f2809cb15123a8e6a6d18d66c6"},
+    {file = "wandb-0.18.7-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e261e9f87005a4487548137d04bfa10fa14e3306b9901bc6ac2f3335c73df7c6"},
+    {file = "wandb-0.18.7-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3133683a5b3bd3a50cf498e6b5ecc7406738619ae9f245326a9fa2e80ad313f"},
+    {file = "wandb-0.18.7-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ca272660d880ba007aa7b4be2f88160692b2f12dccd431bd2f6471c85e68986"},
+    {file = "wandb-0.18.7-py3-none-win32.whl", hash = "sha256:a42b63c9b9e552b51e51b35caf26d81675dbc012317bc2701e39b3d84d479354"},
+    {file = "wandb-0.18.7-py3-none-win_amd64.whl", hash = "sha256:4ba9fda6dd7db02a23c6b302411fe26c3fcfea4947cc130a65e1de19812d324e"},
+    {file = "wandb-0.18.7.tar.gz", hash = "sha256:00f9891558d4833ee47f21ce6c603499f0bd1a7ce117ff55ee1a041e9094f9a2"},
+]
+
+[package.dependencies]
+click = ">=7.1,<8.0.0 || >8.0.0"
+docker-pycreds = ">=0.4.0"
+gitpython = ">=1.0.0,<3.1.29 || >3.1.29"
+platformdirs = "*"
+protobuf = {version = ">=3.19.0,<4.21.0 || >4.21.0,<5.28.0 || >5.28.0,<6", markers = "python_version > \"3.9\" or sys_platform != \"linux\""}
+psutil = ">=5.0.0"
+pyyaml = "*"
+requests = ">=2.0.0,<3"
+sentry-sdk = ">=2.0.0"
+setproctitle = "*"
+setuptools = "*"
+typing-extensions = {version = ">=4.4,<5", markers = "python_version < \"3.12\""}
+
+[package.extras]
+aws = ["boto3"]
+azure = ["azure-identity", "azure-storage-blob"]
+gcp = ["google-cloud-storage"]
+importers = ["filelock", "mlflow", "polars (<=1.2.1)", "rich", "tenacity"]
+kubeflow = ["google-cloud-storage", "kubernetes", "minio", "sh"]
+launch = ["awscli", "azure-containerregistry", "azure-identity", "azure-storage-blob", "boto3", "botocore", "chardet", "google-auth", "google-cloud-aiplatform", "google-cloud-artifact-registry", "google-cloud-compute", "google-cloud-storage", "iso8601", "jsonschema", "kubernetes", "kubernetes-asyncio", "nbconvert", "nbformat", "optuna", "pydantic", "pyyaml (>=6.0.0)", "tomli", "typing-extensions"]
+media = ["bokeh", "imageio", "moviepy", "numpy", "pillow", "plotly (>=5.18.0)", "rdkit", "soundfile"]
+models = ["cloudpickle"]
+perf = ["orjson"]
+sweeps = ["sweeps (>=0.2.0)"]
+workspaces = ["wandb-workspaces"]
+
+[[package]]
 name = "watchdog"
 version = "6.0.0"
 description = "Filesystem events monitoring"
@@ -6648,4 +6931,4 @@ ray = ["ray"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "7d5f2daf5ddbaf2cf37afe1d8a6c28a9a6c70b85e346d4912a1b8045dd957839"
+content-hash = "4e478feb14c693e238439e1ec0510d65529e21b1bdb2fb766e2ff8870f373d09"

--- a/poetry.lock
+++ b/poetry.lock
@@ -6931,4 +6931,4 @@ ray = ["ray"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "4e478feb14c693e238439e1ec0510d65529e21b1bdb2fb766e2ff8870f373d09"
+content-hash = "0a4d48ec1a6380285de6f42dd9b2d844357ce1e9247352da4dce9f930956cb9c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ numpy = ">=1.24.0"
 # Pillow is a transitive dep via matplotlib/imageio; pin >=12.2.0 for CVE-2026-40192
 # (FITS GZIP decompression bomb, introduced in 10.3.0, fixed in 12.2.0).
 pillow = ">=12.2.0"
-wandb = "^0.18"
+wandb = ">=0.18,<1.0"
 ray = {extras = ["tune"], version = "^2.52.0", optional = true}
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ numpy = ">=1.24.0"
 # Pillow is a transitive dep via matplotlib/imageio; pin >=12.2.0 for CVE-2026-40192
 # (FITS GZIP decompression bomb, introduced in 10.3.0, fixed in 12.2.0).
 pillow = ">=12.2.0"
+wandb = "^0.18"
 ray = {extras = ["tune"], version = "^2.52.0", optional = true}
 
 [tool.poetry.extras]

--- a/tensoraerospace/agent/a2c/model.py
+++ b/tensoraerospace/agent/a2c/model.py
@@ -9,6 +9,7 @@ import datetime
 import json
 import time
 from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
 
 import numpy as np
 import torch
@@ -302,6 +303,11 @@ class A2C(BaseRLModel):
         seed=None,
         device=None,
         log_dir=None,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ):
         """Initialize A2C agent.
 
@@ -356,7 +362,20 @@ class A2C(BaseRLModel):
         )
 
         self.log_dir = log_dir
-        self.writer = create_metric_writer(log_dir, algo="a2c")
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        self.writer = create_metric_writer(
+            tb_log_dir=log_dir,
+            wandb_project=wandb_project,
+            wandb_entity=wandb_entity,
+            wandb_run_name=wandb_run_name,
+            wandb_tags=wandb_tags,
+            wandb_config=wandb_config,
+            algo="a2c",
+        )
 
         print(f"A2C initialized on device: {self.device}")
 

--- a/tensoraerospace/agent/a2c/narx.py
+++ b/tensoraerospace/agent/a2c/narx.py
@@ -6,9 +6,8 @@ NARX (Nonlinear AutoRegressive with eXogenous inputs) representations.
 
 import datetime
 import json
-from collections.abc import Sequence
 from pathlib import Path
-from typing import Iterable, Optional, Union
+from typing import Any, Iterable, Mapping, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -219,6 +218,11 @@ class A2CLearner:
         max_grad_norm: float = 0.5,
         device: torch.device | str | None = None,
         log_dir: str | None = None,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ):
         """Initialize learner with optimizers and hyperparameters.
 
@@ -249,7 +253,20 @@ class A2CLearner:
         self.actor_optim = torch.optim.Adam(actor.parameters(), lr=actor_lr)
         self.critic_optim = torch.optim.Adam(critic.parameters(), lr=critic_lr)
         self.log_dir = log_dir
-        self.writer = create_metric_writer(log_dir, algo="a2c-narx")
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        self.writer = create_metric_writer(
+            tb_log_dir=log_dir,
+            wandb_project=wandb_project,
+            wandb_entity=wandb_entity,
+            wandb_run_name=wandb_run_name,
+            wandb_tags=wandb_tags,
+            wandb_config=wandb_config,
+            algo="a2c-narx",
+        )
         self.update_count = 0
 
     def learn(

--- a/tensoraerospace/agent/a3c/pytorch.py
+++ b/tensoraerospace/agent/a3c/pytorch.py
@@ -22,7 +22,7 @@ try:  # Prefer gymnasium when available for typing accuracy
 except ImportError:  # pragma: no cover - fallback for older environments
     import gym
 
-from ..metrics import create_metric_writer, schema
+from ..metrics import MetricWriter, create_metric_writer, schema
 from .shared_optim import SharedAdam
 from .utils import push_and_pull, record, set_init, v_wrap
 
@@ -506,7 +506,7 @@ class Agent:
         self.wandb_config = wandb_config
 
         # TensorBoard writer
-        self.writer: Optional["torch.utils.tensorboard.SummaryWriter"] = None
+        self.writer: Optional[MetricWriter] = None
         try:
             self.writer = create_metric_writer(
                 tb_log_dir=log_dir,

--- a/tensoraerospace/agent/a3c/pytorch.py
+++ b/tensoraerospace/agent/a3c/pytorch.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import datetime
 import json
 from pathlib import Path
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -443,6 +443,11 @@ class Agent:
         render: bool = False,
         run_in_main: bool = False,
         log_dir: str = "runs/a3c",
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Configure A3C agent wrapper.
 
@@ -493,10 +498,25 @@ class Agent:
         # extensions for multiprocessing types.
         self.res_queue: "mp.Queue" = mp.Queue()
 
+        # Store wandb kwargs for completeness/consistency.
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+
         # TensorBoard writer
         self.writer: Optional["torch.utils.tensorboard.SummaryWriter"] = None
         try:
-            self.writer = create_metric_writer(log_dir, algo="a3c")
+            self.writer = create_metric_writer(
+                tb_log_dir=log_dir,
+                wandb_project=wandb_project,
+                wandb_entity=wandb_entity,
+                wandb_run_name=wandb_run_name,
+                wandb_tags=wandb_tags,
+                wandb_config=wandb_config,
+                algo="a3c",
+            )
         except Exception:
             self.writer = None
 

--- a/tensoraerospace/agent/adhdp/model.py
+++ b/tensoraerospace/agent/adhdp/model.py
@@ -25,7 +25,7 @@ import datetime
 import inspect
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -151,6 +151,11 @@ class ADHDP(BaseRLModel):
         actor_bc_decay: float = 1.0,
         log_dir: Union[str, Path, None] = None,
         log_every_updates: int = 500,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Initialize the ADHDP agent.
 
@@ -450,7 +455,20 @@ class ADHDP(BaseRLModel):
         self.critic_optim = Adam(self.critic.parameters(), lr=float(critic_lr))
 
         self.log_dir = Path(log_dir) if log_dir is not None else None
-        self.writer = create_metric_writer(self.log_dir, algo="adhdp")
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        self.writer = create_metric_writer(
+            tb_log_dir=self.log_dir,
+            wandb_project=wandb_project,
+            wandb_entity=wandb_entity,
+            wandb_run_name=wandb_run_name,
+            wandb_tags=wandb_tags,
+            wandb_config=wandb_config,
+            algo="adhdp",
+        )
         self.log_every_updates = int(log_every_updates)
         self._updates = 0
 

--- a/tensoraerospace/agent/adp/adp.py
+++ b/tensoraerospace/agent/adp/adp.py
@@ -30,7 +30,7 @@ import datetime
 import inspect
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -155,6 +155,11 @@ class ADP(BaseRLModel):
         # Paper Section III: alternating critic/action training cycles (keep the other fixed)
         dhp_critic_cycle_episodes: int = 0,
         dhp_action_cycle_episodes: int = 0,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         super().__init__()
         self.env = env
@@ -473,7 +478,20 @@ class ADP(BaseRLModel):
             self.memory = None
 
         self.log_dir = Path(log_dir) if log_dir is not None else None
-        self.writer = create_metric_writer(self.log_dir, algo="adp")
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        self.writer = create_metric_writer(
+            tb_log_dir=self.log_dir,
+            wandb_project=wandb_project,
+            wandb_entity=wandb_entity,
+            wandb_run_name=wandb_run_name,
+            wandb_tags=wandb_tags,
+            wandb_config=wandb_config,
+            algo="adp",
+        )
         self.log_every_updates = int(log_every_updates)
         if self.log_every_updates < 1:
             raise ValueError("log_every_updates must be >= 1")

--- a/tensoraerospace/agent/ddpg/model.py
+++ b/tensoraerospace/agent/ddpg/model.py
@@ -11,7 +11,7 @@ import json
 import os
 import random
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -574,6 +574,11 @@ class DDPG:
         replay_buffer_size: int,
         normalize_observations: bool = True,
         device: Optional[Union[str, torch.device]] = None,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Initialize DDPG agent.
 
@@ -658,6 +663,13 @@ class DDPG:
         self.value_criterion = nn.MSELoss()
 
         self.replay_buffer = ReplayBuffer(self.replay_buffer_size)
+
+        # Stored wandb kwargs forwarded to the lazy writer in learn().
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
 
         # TensorBoard writer (lazy init in learn to include run-time params)
         self.writer = None
@@ -896,7 +908,15 @@ class DDPG:
             try:
                 logdir = os.path.join("runs", "ddpg")
                 os.makedirs(logdir, exist_ok=True)
-                self.writer = create_metric_writer(logdir, algo="ddpg")
+                self.writer = create_metric_writer(
+                    tb_log_dir=logdir,
+                    wandb_project=self.wandb_project,
+                    wandb_entity=self.wandb_entity,
+                    wandb_run_name=self.wandb_run_name,
+                    wandb_tags=self.wandb_tags,
+                    wandb_config=self.wandb_config,
+                    algo="ddpg",
+                )
             except Exception:
                 self.writer = None
 

--- a/tensoraerospace/agent/dqn/model.py
+++ b/tensoraerospace/agent/dqn/model.py
@@ -7,7 +7,7 @@ buffer helpers) used in TensorAeroSpace.
 import json
 import time
 from pathlib import Path
-from typing import Any, Optional, Tuple, Union, cast
+from typing import Any, Mapping, Optional, Sequence, Tuple, Union, cast
 
 import gymnasium as gym
 import numpy as np
@@ -256,6 +256,11 @@ class DQNAgent:
         log_dir: str | None = None,
         verbose_histogram: bool = False,
         seed: int = 1,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Initialize DQN agent and replay buffer.
 
@@ -289,7 +294,20 @@ class DQNAgent:
         self.target_model = target_model.to(self.device)
         self.optimizer = torch.optim.Adam(self.model.parameters(), lr=learning_rate)
         self.log_dir = Path(log_dir) if log_dir is not None else None
-        self.writer = create_metric_writer(self.log_dir, algo="dqn")
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        self.writer = create_metric_writer(
+            tb_log_dir=self.log_dir,
+            wandb_project=wandb_project,
+            wandb_entity=wandb_entity,
+            wandb_run_name=wandb_run_name,
+            wandb_tags=wandb_tags,
+            wandb_config=wandb_config,
+            algo="dqn",
+        )
 
         # parameters
         self.env = env  # gym environment
@@ -926,6 +944,11 @@ class PERNARXAgent:
         beta_increment_per_sample: float = 0.001,
         log_dir: str | None = None,
         verbose_histogram: bool = False,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Initialize PER-NARX agent and buffers.
 
@@ -954,7 +977,20 @@ class PERNARXAgent:
         self.target_model = target_model.to(self.device)
         self.optimizer = torch.optim.Adam(self.model.parameters(), lr=learning_rate)
         self.log_dir = Path(log_dir) if log_dir is not None else None
-        self.writer = create_metric_writer(self.log_dir, algo="dqn-narx")
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        self.writer = create_metric_writer(
+            tb_log_dir=self.log_dir,
+            wandb_project=wandb_project,
+            wandb_entity=wandb_entity,
+            wandb_run_name=wandb_run_name,
+            wandb_tags=wandb_tags,
+            wandb_config=wandb_config,
+            algo="dqn-narx",
+        )
 
         # parameters
         self.env = env  # gym environment

--- a/tensoraerospace/agent/dsac/dsac_flight.py
+++ b/tensoraerospace/agent/dsac/dsac_flight.py
@@ -15,7 +15,7 @@ import datetime
 import inspect
 import json
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, Union, cast
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 import torch
@@ -118,6 +118,11 @@ class DSAC(BaseRLModel):
         seed: int = 42,
         log_dir: Union[str, Path, None] = None,
         log_every_updates: int = 1,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         super().__init__()
         self._global_train_vector_step = 0
@@ -128,7 +133,20 @@ class DSAC(BaseRLModel):
 
         self.device = torch.device(device)
         self.log_dir = Path(log_dir) if log_dir is not None else None
-        self.writer = create_metric_writer(self.log_dir, algo="dsac")
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        self.writer = create_metric_writer(
+            tb_log_dir=self.log_dir,
+            wandb_project=wandb_project,
+            wandb_entity=wandb_entity,
+            wandb_run_name=wandb_run_name,
+            wandb_tags=wandb_tags,
+            wandb_config=wandb_config,
+            algo="dsac",
+        )
         # Cumulative env step at the time update_parameters() is invoked.
         # Updated by train()/train_vector() before each call.
         self._last_env_step = 0

--- a/tensoraerospace/agent/et_dhp/model.py
+++ b/tensoraerospace/agent/et_dhp/model.py
@@ -34,9 +34,10 @@ from __future__ import annotations
 import dataclasses
 import datetime
 import json
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Union
 
 import numpy as np
 import torch
@@ -188,6 +189,11 @@ class ETDHPAgent:
         ) = None,
         config: ETDHPConfig | None = None,
         log_dir: Union[str, Path, None] = None,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         self.n_state = int(n_state)
         self.n_control = int(n_control)
@@ -265,15 +271,32 @@ class ETDHPAgent:
         }
 
         # ----- Unified TensorBoard metrics -----
-        # Only create the writer when an explicit log_dir is provided so the
-        # default no-logging path stays a true no-op (existing tests don't
-        # pass log_dir and must continue working without TB side effects).
+        # Only create the writer when an explicit log_dir is provided, OR when
+        # a wandb backend has been requested (explicit project / WANDB_API_KEY
+        # in env). This keeps the default no-logging path a true no-op.
         self.log_dir = Path(log_dir) if log_dir is not None else None
-        self.writer = (
-            create_metric_writer(self.log_dir, algo="etdhp")
-            if self.log_dir is not None
-            else None
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        needs_writer = (
+            self.log_dir is not None
+            or wandb_project is not None
+            or os.environ.get("WANDB_API_KEY") is not None
         )
+        if needs_writer:
+            self.writer = create_metric_writer(
+                tb_log_dir=self.log_dir,
+                wandb_project=wandb_project,
+                wandb_entity=wandb_entity,
+                wandb_run_name=wandb_run_name,
+                wandb_tags=wandb_tags,
+                wandb_config=wandb_config,
+                algo="etdhp",
+            )
+        else:
+            self.writer = None
         self.global_env_step = 0
         self.update_count = 0
 

--- a/tensoraerospace/agent/gail/model.py
+++ b/tensoraerospace/agent/gail/model.py
@@ -7,9 +7,10 @@ components used for imitation learning within TensorAeroSpace.
 import datetime
 import json
 import math
+import os
 import random
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import gymnasium as gym
 import numpy as np
@@ -151,6 +152,11 @@ class GAIL:
         epochs: int,
         data: np.ndarray,
         log_dir: Union[str, Path, None] = None,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ):
         """Initialize the GAIL algorithm.
 
@@ -186,11 +192,28 @@ class GAIL:
         self.optimizer_discrim = optim.Adam(self.discriminator.parameters(), lr=self.lr)
 
         self.log_dir = Path(log_dir) if log_dir is not None else None
-        self.writer = (
-            create_metric_writer(self.log_dir, algo="gail")
-            if log_dir is not None
-            else None
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        needs_writer = (
+            log_dir is not None
+            or wandb_project is not None
+            or os.environ.get("WANDB_API_KEY") is not None
         )
+        if needs_writer:
+            self.writer = create_metric_writer(
+                tb_log_dir=self.log_dir,
+                wandb_project=wandb_project,
+                wandb_entity=wandb_entity,
+                wandb_run_name=wandb_run_name,
+                wandb_tags=wandb_tags,
+                wandb_config=wandb_config,
+                algo="gail",
+            )
+        else:
+            self.writer = None
         self.global_env_step = 0
         self.update_count = 0
         self.discrim_update_count = 0

--- a/tensoraerospace/agent/metrics/writer.py
+++ b/tensoraerospace/agent/metrics/writer.py
@@ -46,6 +46,30 @@ class _LazyTorchSummaryWriter:
 TorchSummaryWriter = _LazyTorchSummaryWriter()
 
 
+class _TensorBoardSink:
+    """Sink that forwards metrics to a torch.utils.tensorboard.SummaryWriter."""
+
+    def __init__(self, log_dir: Optional[Union[str, Path]]) -> None:
+        log_path = str(log_dir) if log_dir is not None else None
+        self._writer = (
+            TorchSummaryWriter(log_dir=log_path)
+            if log_path is not None
+            else TorchSummaryWriter()
+        )
+
+    def add_scalar(self, tag: str, value: float, env_step: int) -> None:
+        self._writer.add_scalar(tag, value, env_step)
+
+    def add_histogram(self, tag: str, values, env_step: int) -> None:
+        self._writer.add_histogram(tag, values, env_step)
+
+    def flush(self) -> None:
+        self._writer.flush()
+
+    def close(self) -> None:
+        self._writer.close()
+
+
 class MetricWriter:
     """SummaryWriter wrapper that enforces the canonical metric schema.
 
@@ -72,12 +96,7 @@ class MetricWriter:
         required: Iterable[str] = MANDATORY_METRICS,
         algo: Optional[str] = None,
     ) -> None:
-        log_path = str(log_dir) if log_dir is not None else None
-        self._writer = (
-            TorchSummaryWriter(log_dir=log_path)
-            if log_path is not None
-            else TorchSummaryWriter()
-        )
+        self._sinks: list = [_TensorBoardSink(log_dir)]
         self._strict = strict
         self._required = tuple(required)
         self._algo = algo
@@ -94,7 +113,8 @@ class MetricWriter:
                 "or construct MetricWriter(strict=False)."
             )
         self._written.add(schema.strip_worker_suffix(tag))
-        self._writer.add_scalar(tag, value, env_step)
+        for sink in self._sinks:
+            sink.add_scalar(tag, value, env_step)
 
     def add_histogram(self, tag: str, values, env_step: int) -> None:
         if self._strict and not schema.is_registered_histogram(tag):
@@ -104,7 +124,8 @@ class MetricWriter:
                 "grads/<group>/<param> with <group> in "
                 f"{sorted(schema.HISTOGRAM_SUBGROUPS)}."
             )
-        self._writer.add_histogram(tag, values, env_step)
+        for sink in self._sinks:
+            sink.add_histogram(tag, values, env_step)
 
     # -- sugar -------------------------------------------------------------
 
@@ -135,10 +156,12 @@ class MetricWriter:
     # -- lifecycle ---------------------------------------------------------
 
     def flush(self) -> None:
-        self._writer.flush()
+        for sink in self._sinks:
+            sink.flush()
 
     def close(self) -> None:
-        self._writer.close()
+        for sink in self._sinks:
+            sink.close()
 
 
 def create_metric_writer(

--- a/tensoraerospace/agent/metrics/writer.py
+++ b/tensoraerospace/agent/metrics/writer.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
-from typing import Iterable, Optional, Set, Union
+from typing import Any, Iterable, Mapping, Optional, Sequence, Set, Union
+
+import wandb  # type: ignore[import-untyped]
 
 from . import schema
 from .contract import MANDATORY_METRICS, check_contract
@@ -68,6 +71,45 @@ class _TensorBoardSink:
 
     def close(self) -> None:
         self._writer.close()
+
+
+class _WandbSink:
+    """Sink that forwards metrics to Weights & Biases."""
+
+    def __init__(
+        self,
+        *,
+        project: str,
+        entity: Optional[str],
+        run_name: Optional[str],
+        tags: Optional[Sequence[str]],
+        config: Optional[Mapping[str, Any]],
+    ) -> None:
+        if not os.environ.get("WANDB_API_KEY"):
+            wandb.login()
+        self._run = wandb.init(
+            project=project,
+            entity=entity,
+            name=run_name,
+            tags=list(tags) if tags else None,
+            config=dict(config) if config else None,
+            reinit=True,
+            settings=wandb.Settings(start_method="thread"),
+        )
+
+    def add_scalar(self, tag: str, value: float, env_step: int) -> None:
+        wandb.log({tag: float(value)}, step=int(env_step))
+
+    def add_histogram(self, tag: str, values, env_step: int) -> None:
+        wandb.log({tag: wandb.Histogram(values)}, step=int(env_step))
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        if self._run is not None:
+            self._run.finish()
+            self._run = None
 
 
 class MetricWriter:

--- a/tensoraerospace/agent/metrics/writer.py
+++ b/tensoraerospace/agent/metrics/writer.py
@@ -132,13 +132,30 @@ class MetricWriter:
 
     def __init__(
         self,
-        log_dir: Optional[Union[str, Path]] = None,
+        tb_log_dir: Optional[Union[str, Path]] = None,
         *,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
         strict: bool = True,
         required: Iterable[str] = MANDATORY_METRICS,
         algo: Optional[str] = None,
     ) -> None:
-        self._sinks: list = [_TensorBoardSink(log_dir)]
+        self._sinks: list = []
+        if tb_log_dir is not None:
+            self._sinks.append(_TensorBoardSink(tb_log_dir))
+        if wandb_project is not None:
+            self._sinks.append(
+                _WandbSink(
+                    project=wandb_project,
+                    entity=wandb_entity,
+                    run_name=wandb_run_name,
+                    tags=wandb_tags,
+                    config=wandb_config,
+                )
+            )
         self._strict = strict
         self._required = tuple(required)
         self._algo = algo
@@ -213,4 +230,4 @@ def create_metric_writer(
     algo: Optional[str] = None,
 ) -> MetricWriter:
     """Factory used by agents — keeps call sites short."""
-    return MetricWriter(log_dir=log_dir, strict=strict, algo=algo)
+    return MetricWriter(tb_log_dir=log_dir, strict=strict, algo=algo)

--- a/tensoraerospace/agent/metrics/writer.py
+++ b/tensoraerospace/agent/metrics/writer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime as _dt
 import os
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Sequence, Set, Union
@@ -224,10 +225,53 @@ class MetricWriter:
 
 
 def create_metric_writer(
-    log_dir: Optional[Union[str, Path]] = None,
+    tb_log_dir: Optional[Union[str, Path]] = None,
     *,
+    wandb_project: Optional[str] = None,
+    wandb_entity: Optional[str] = None,
+    wandb_run_name: Optional[str] = None,
+    wandb_tags: Optional[Sequence[str]] = None,
+    wandb_config: Optional[Mapping[str, Any]] = None,
     strict: bool = True,
     algo: Optional[str] = None,
 ) -> MetricWriter:
-    """Factory used by agents — keeps call sites short."""
-    return MetricWriter(tb_log_dir=log_dir, strict=strict, algo=algo)
+    """Construct a MetricWriter with auto-detection of the wandb backend.
+
+    Activation rules:
+      * tb_log_dir set                          -> TB sink active.
+      * wandb_project set                       -> wandb sink active (calls
+                                                   wandb.login() if no key).
+      * WANDB_API_KEY in env, no wandb_project  -> wandb sink active with
+                                                   project = algo (or
+                                                   "tensoraerospace").
+
+    In multi-worker (forked) processes, wandb is skipped.
+    """
+    import multiprocessing
+
+    is_main_process = multiprocessing.current_process().name == "MainProcess"
+
+    wandb_enabled = is_main_process and (
+        wandb_project is not None or os.environ.get("WANDB_API_KEY") is not None
+    )
+
+    if wandb_enabled:
+        resolved_project = wandb_project or algo or "tensoraerospace"
+        if wandb_run_name is None:
+            ts = _dt.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+            wandb_run_name = f"{algo or 'run'}-{ts}"
+        if wandb_tags is None and algo is not None:
+            wandb_tags = [algo]
+    else:
+        resolved_project = None
+
+    return MetricWriter(
+        tb_log_dir=tb_log_dir,
+        wandb_project=resolved_project,
+        wandb_entity=wandb_entity,
+        wandb_run_name=wandb_run_name,
+        wandb_tags=wandb_tags,
+        wandb_config=wandb_config,
+        strict=strict,
+        algo=algo,
+    )

--- a/tensoraerospace/agent/metrics/writer.py
+++ b/tensoraerospace/agent/metrics/writer.py
@@ -99,10 +99,10 @@ class _WandbSink:
         )
 
     def add_scalar(self, tag: str, value: float, env_step: int) -> None:
-        wandb.log({tag: float(value)}, step=int(env_step))
+        self._run.log({tag: float(value)}, step=int(env_step))
 
     def add_histogram(self, tag: str, values, env_step: int) -> None:
-        wandb.log({tag: wandb.Histogram(values)}, step=int(env_step))
+        self._run.log({tag: wandb.Histogram(values)}, step=int(env_step))
 
     def flush(self) -> None:
         pass
@@ -114,21 +114,32 @@ class _WandbSink:
 
 
 class MetricWriter:
-    """SummaryWriter wrapper that enforces the canonical metric schema.
+    """Strict-whitelist writer that fans out metrics to one or more sinks.
+
+    Sinks are activated via the constructor:
+
+    * ``tb_log_dir`` set            -> TensorBoard sink active.
+    * ``wandb_project`` set         -> Weights & Biases sink active.
+
+    With both unset, the writer is a no-op for logging — but the strict
+    whitelist still rejects unregistered tags. Use ``create_metric_writer``
+    for environment-based auto-detection (e.g. ``WANDB_API_KEY``).
 
     Parameters
     ----------
-    log_dir
-        TensorBoard log directory.
-    strict
-        If True, ``add_scalar``/``add_histogram`` raise ``ValueError`` for tags
-        not in ``schema.REGISTRY`` (after stripping multi-worker suffix) or not
-        matching the histogram prefix rule.
-    required
-        Tuple of tags that must be written at least once during the writer's
-        lifetime. Checked by ``assert_contract_satisfied``.
-    algo
-        Optional algorithm label, included in error messages.
+    tb_log_dir : path or None
+        Directory for TensorBoard event files. Triggers TB sink.
+    wandb_project, wandb_entity, wandb_run_name, wandb_tags, wandb_config :
+        Wandb run configuration. Setting ``wandb_project`` triggers wandb
+        sink (calls ``wandb.login()`` if no API key is set).
+    strict : bool
+        If True (default), unknown tags raise ``ValueError``.
+    required : iterable[str]
+        Tags that must be written at least once before
+        ``assert_contract_satisfied()`` returns clean.
+    algo : str or None
+        Algorithm label included in error messages and used as default
+        wandb project / tag.
     """
 
     def __init__(

--- a/tensoraerospace/agent/ppo/model.py
+++ b/tensoraerospace/agent/ppo/model.py
@@ -13,7 +13,7 @@ import os
 import queue
 import threading
 from pathlib import Path
-from typing import Any, Dict, Generator, Optional, Tuple, Union, overload
+from typing import Any, Dict, Generator, Mapping, Optional, Sequence, Tuple, Union, overload
 
 import numpy as np
 import torch
@@ -543,6 +543,11 @@ class PPO(BaseRLModel):
         save_best_model: bool = True,
         best_model_dir: Union[str, Path, None] = None,
         save_best_async: bool = True,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Initialize agent with given environment and discount coefficient.
 
@@ -619,7 +624,20 @@ class PPO(BaseRLModel):
         self.best_reward = float("-inf")
         self.avg_rewards_list: list = []
         self.log_dir = Path(log_dir) if log_dir is not None else None
-        self.writer = create_metric_writer(self.log_dir, algo="ppo")
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        self.writer = create_metric_writer(
+            tb_log_dir=self.log_dir,
+            wandb_project=wandb_project,
+            wandb_entity=wandb_entity,
+            wandb_run_name=wandb_run_name,
+            wandb_tags=wandb_tags,
+            wandb_config=wandb_config,
+            algo="ppo",
+        )
         # Cumulative env-step counter for canonical TB metric x-axis. Incremented
         # after every self.env.step() call (per parallel env for vector envs).
         self.global_env_step = 0

--- a/tensoraerospace/agent/ppo/model.py
+++ b/tensoraerospace/agent/ppo/model.py
@@ -13,7 +13,17 @@ import os
 import queue
 import threading
 from pathlib import Path
-from typing import Any, Dict, Generator, Mapping, Optional, Sequence, Tuple, Union, overload
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    overload,
+)
 
 import numpy as np
 import torch

--- a/tensoraerospace/agent/sac/sac.py
+++ b/tensoraerospace/agent/sac/sac.py
@@ -10,7 +10,7 @@ import inspect
 import json
 from collections import deque
 from pathlib import Path
-from typing import Any, Deque, Dict, Optional, Tuple, Union, cast
+from typing import Any, Deque, Dict, Mapping, Optional, Sequence, Tuple, Union, cast
 
 import numpy as np
 import torch
@@ -80,6 +80,11 @@ class SAC(BaseRLModel):
         seed: int = 42,
         log_dir: Union[str, Path, None] = None,
         log_every_updates: int = 1,
+        wandb_project: Optional[str] = None,
+        wandb_entity: Optional[str] = None,
+        wandb_run_name: Optional[str] = None,
+        wandb_tags: Optional[Sequence[str]] = None,
+        wandb_config: Optional[Mapping[str, Any]] = None,
     ) -> None:
         """Initialize SAC agent, networks, replay buffer, and optimizers."""
         super().__init__()
@@ -101,7 +106,20 @@ class SAC(BaseRLModel):
         num_inputs = self.env.observation_space.shape[0]
         self.device = torch.device(device)
         self.log_dir = Path(log_dir) if log_dir is not None else None
-        self.writer = create_metric_writer(self.log_dir, algo="sac")
+        self.wandb_project = wandb_project
+        self.wandb_entity = wandb_entity
+        self.wandb_run_name = wandb_run_name
+        self.wandb_tags = wandb_tags
+        self.wandb_config = wandb_config
+        self.writer = create_metric_writer(
+            tb_log_dir=self.log_dir,
+            wandb_project=wandb_project,
+            wandb_entity=wandb_entity,
+            wandb_run_name=wandb_run_name,
+            wandb_tags=wandb_tags,
+            wandb_config=wandb_config,
+            algo="sac",
+        )
         # Cumulative env step at the time update_parameters() is invoked.
         # Updated by train()/train_vector() before each call.
         self._last_env_step = 0

--- a/tests/agents/a3c_wandb_parent_only_test.py
+++ b/tests/agents/a3c_wandb_parent_only_test.py
@@ -1,0 +1,52 @@
+"""Multi-worker guard: workers must not initialize wandb."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tensoraerospace.agent.metrics import create_metric_writer
+from tensoraerospace.agent.metrics import writer as writer_mod
+
+
+@pytest.fixture
+def mock_wandb(monkeypatch):
+    mock = MagicMock()
+    mock.init = MagicMock(return_value=MagicMock())
+    mock.Settings = MagicMock(return_value="S")
+    monkeypatch.setattr(writer_mod, "wandb", mock, raising=False)
+    return mock
+
+
+def test_in_main_process_wandb_init_runs(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    w = create_metric_writer(algo="a3c")
+    assert len(w._sinks) == 1
+    mock_wandb.init.assert_called_once()
+
+
+def test_in_worker_process_wandb_skipped(monkeypatch, mock_wandb):
+    """When not running as MainProcess, wandb sink is omitted."""
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+
+    fake_proc = MagicMock()
+    fake_proc.name = "Worker-1"
+    with patch("multiprocessing.current_process", return_value=fake_proc):
+        w = create_metric_writer(algo="a3c")
+
+    assert len(w._sinks) == 0
+    mock_wandb.init.assert_not_called()
+
+
+def test_in_worker_process_explicit_wandb_project_still_skipped(
+    monkeypatch, mock_wandb
+):
+    """Even an explicit wandb_project doesn't override the worker guard."""
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    fake_proc = MagicMock()
+    fake_proc.name = "Worker-2"
+    with patch("multiprocessing.current_process", return_value=fake_proc):
+        w = create_metric_writer(wandb_project="exp", algo="a3c")
+    assert len(w._sinks) == 0
+    mock_wandb.init.assert_not_called()

--- a/tests/agents/metrics_dual_sink_smoke_test.py
+++ b/tests/agents/metrics_dual_sink_smoke_test.py
@@ -1,0 +1,70 @@
+"""Dual-sink end-to-end: SAC.train() writes to both TB and (mocked) wandb."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensoraerospace.agent.metrics import writer as writer_mod
+from tensoraerospace.agent.metrics import schema
+from tests.agents.metrics_contract_smoke_test import assert_tags_present
+
+
+REQUIRED = {
+    schema.ROLLOUT_EPISODE_REWARD,
+    schema.ROLLOUT_EPISODE_LENGTH,
+    schema.ROLLOUT_TOTAL_STEPS,
+    schema.TRAIN_UPDATES,
+    schema.TRAIN_LR,
+    schema.TRAIN_REPLAY_SIZE,
+    schema.SAC.LOSS_Q1,
+    schema.LOSS_POLICY,
+}
+
+
+@pytest.mark.timeout(120)
+def test_sac_writes_to_both_tb_and_wandb(tmp_path: Path, monkeypatch):
+    pytest.importorskip("torch")
+    pytest.importorskip("gymnasium")
+    pytest.importorskip("tensorboard")
+
+    import gymnasium as gym
+    from tensoraerospace.agent.sac.sac import SAC
+
+    # Mock wandb so the test doesn't hit the network
+    mock_wandb = MagicMock()
+    mock_wandb.init = MagicMock(return_value=MagicMock())
+    mock_wandb.Settings = MagicMock(return_value="S")
+    mock_wandb.Histogram = MagicMock(side_effect=lambda v: ("H", v))
+    monkeypatch.setattr(writer_mod, "wandb", mock_wandb, raising=False)
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+
+    env = gym.make("Pendulum-v1")
+    log_dir = tmp_path / "tb"
+
+    agent = SAC(
+        env=env,
+        batch_size=16,
+        memory_capacity=2_000,
+        log_dir=str(log_dir),
+        wandb_project="dual-sink-test",
+        device="cpu",
+    )
+    agent.train(num_episodes=1, max_steps=64, verbose=False)
+    agent.writer.flush()
+
+    # TB side: tags appear in event files
+    assert_tags_present(str(log_dir), REQUIRED)
+
+    # Wandb side: the same tags appear in mocked wandb.log calls
+    logged_keys = set()
+    for call in mock_wandb.log.call_args_list:
+        payload = call.args[0] if call.args else call.kwargs.get("data", {})
+        logged_keys.update(payload.keys())
+    missing = REQUIRED - logged_keys
+    assert not missing, (
+        f"Tags missing from wandb.log calls: {sorted(missing)}; "
+        f"got {sorted(logged_keys)}"
+    )

--- a/tests/agents/metrics_dual_sink_smoke_test.py
+++ b/tests/agents/metrics_dual_sink_smoke_test.py
@@ -35,7 +35,8 @@ def test_sac_writes_to_both_tb_and_wandb(tmp_path: Path, monkeypatch):
 
     # Mock wandb so the test doesn't hit the network
     mock_wandb = MagicMock()
-    mock_wandb.init = MagicMock(return_value=MagicMock())
+    mock_run = MagicMock()
+    mock_wandb.init = MagicMock(return_value=mock_run)
     mock_wandb.Settings = MagicMock(return_value="S")
     mock_wandb.Histogram = MagicMock(side_effect=lambda v: ("H", v))
     monkeypatch.setattr(writer_mod, "wandb", mock_wandb, raising=False)
@@ -58,13 +59,13 @@ def test_sac_writes_to_both_tb_and_wandb(tmp_path: Path, monkeypatch):
     # TB side: tags appear in event files
     assert_tags_present(str(log_dir), REQUIRED)
 
-    # Wandb side: the same tags appear in mocked wandb.log calls
+    # Wandb side: the same tags appear in mocked run.log calls
     logged_keys = set()
-    for call in mock_wandb.log.call_args_list:
+    for call in mock_run.log.call_args_list:
         payload = call.args[0] if call.args else call.kwargs.get("data", {})
         logged_keys.update(payload.keys())
     missing = REQUIRED - logged_keys
     assert not missing, (
-        f"Tags missing from wandb.log calls: {sorted(missing)}; "
+        f"Tags missing from run.log calls: {sorted(missing)}; "
         f"got {sorted(logged_keys)}"
     )

--- a/tests/agents/metrics_dual_sink_smoke_test.py
+++ b/tests/agents/metrics_dual_sink_smoke_test.py
@@ -7,10 +7,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from tensoraerospace.agent.metrics import writer as writer_mod
 from tensoraerospace.agent.metrics import schema
+from tensoraerospace.agent.metrics import writer as writer_mod
 from tests.agents.metrics_contract_smoke_test import assert_tags_present
-
 
 REQUIRED = {
     schema.ROLLOUT_EPISODE_REWARD,
@@ -31,6 +30,7 @@ def test_sac_writes_to_both_tb_and_wandb(tmp_path: Path, monkeypatch):
     pytest.importorskip("tensorboard")
 
     import gymnasium as gym
+
     from tensoraerospace.agent.sac.sac import SAC
 
     # Mock wandb so the test doesn't hit the network

--- a/tests/agents/metrics_factory_test.py
+++ b/tests/agents/metrics_factory_test.py
@@ -1,0 +1,106 @@
+"""Auto-activation behaviour of create_metric_writer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tensoraerospace.agent.metrics import create_metric_writer
+from tensoraerospace.agent.metrics import writer as writer_mod
+
+
+@pytest.fixture
+def mock_wandb(monkeypatch):
+    mock = MagicMock()
+    mock.init = MagicMock(return_value=MagicMock())
+    mock.Settings = MagicMock(return_value="S")
+    mock.Histogram = MagicMock(side_effect=lambda v: ("H", v))
+    monkeypatch.setattr(writer_mod, "wandb", mock, raising=False)
+    return mock
+
+
+def test_tb_only_when_only_tb_log_dir(tmp_path: Path, monkeypatch, mock_wandb):
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    w = create_metric_writer(tb_log_dir=str(tmp_path / "tb"), algo="sac")
+    assert len(w._sinks) == 1
+    mock_wandb.init.assert_not_called()
+
+
+def test_wandb_only_when_only_api_key(tmp_path: Path, monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    w = create_metric_writer(algo="sac")
+    assert len(w._sinks) == 1
+    mock_wandb.init.assert_called_once()
+    assert mock_wandb.init.call_args.kwargs["project"] == "sac"
+
+
+def test_both_when_tb_log_dir_and_api_key(tmp_path: Path, monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    w = create_metric_writer(tb_log_dir=str(tmp_path / "tb"), algo="ppo")
+    assert len(w._sinks) == 2
+    mock_wandb.init.assert_called_once()
+
+
+def test_zero_sinks_when_nothing(monkeypatch, mock_wandb):
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    w = create_metric_writer(algo="sac")
+    assert len(w._sinks) == 0
+    with pytest.raises(ValueError):
+        w.add_scalar("not/in/schema", 1.0, env_step=1)
+
+
+def test_explicit_wandb_project_calls_login_when_api_key_missing(
+    monkeypatch, mock_wandb
+):
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    create_metric_writer(wandb_project="my-exp", algo="sac")
+    mock_wandb.login.assert_called_once()
+    mock_wandb.init.assert_called_once()
+    assert mock_wandb.init.call_args.kwargs["project"] == "my-exp"
+
+
+def test_default_project_uses_algo_when_only_api_key(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer(algo="ddpg")
+    assert mock_wandb.init.call_args.kwargs["project"] == "ddpg"
+
+
+def test_default_project_falls_back_when_no_algo(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer()
+    assert mock_wandb.init.call_args.kwargs["project"] == "tensoraerospace"
+
+
+def test_default_run_name_includes_algo_and_timestamp(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer(algo="sac")
+    name = mock_wandb.init.call_args.kwargs["name"]
+    assert name.startswith("sac-")
+    assert len(name) > len("sac-")
+
+
+def test_default_tags_contain_algo(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer(algo="dqn")
+    tags = mock_wandb.init.call_args.kwargs["tags"]
+    assert "dqn" in tags
+
+
+def test_explicit_kwargs_override_defaults(monkeypatch, mock_wandb):
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+    create_metric_writer(
+        algo="sac",
+        wandb_project="p",
+        wandb_entity="e",
+        wandb_run_name="r",
+        wandb_tags=["t1", "t2"],
+        wandb_config={"k": "v"},
+    )
+    kw = mock_wandb.init.call_args.kwargs
+    assert kw["project"] == "p"
+    assert kw["entity"] == "e"
+    assert kw["name"] == "r"
+    assert kw["tags"] == ["t1", "t2"]
+    assert kw["config"] == {"k": "v"}

--- a/tests/agents/metrics_wandb_sink_test.py
+++ b/tests/agents/metrics_wandb_sink_test.py
@@ -60,28 +60,28 @@ def test_init_calls_login_when_api_key_missing(mock_wandb, monkeypatch):
 
 def test_add_scalar_calls_wandb_log(mock_wandb, monkeypatch):
     from tensoraerospace.agent.metrics.writer import _WandbSink
-    mock, _ = mock_wandb
+    mock, mock_run = mock_wandb
     monkeypatch.setenv("WANDB_API_KEY", "fake-key")
     sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
-    mock.log.reset_mock()
+    mock_run.log.reset_mock()
 
     sink.add_scalar("loss/actor", 0.123, env_step=10)
 
-    mock.log.assert_called_once_with({"loss/actor": 0.123}, step=10)
+    mock_run.log.assert_called_once_with({"loss/actor": 0.123}, step=10)
 
 
 def test_add_histogram_wraps_in_wandb_histogram(mock_wandb, monkeypatch):
     from tensoraerospace.agent.metrics.writer import _WandbSink
-    mock, _ = mock_wandb
+    mock, mock_run = mock_wandb
     monkeypatch.setenv("WANDB_API_KEY", "fake-key")
     sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
-    mock.log.reset_mock()
+    mock_run.log.reset_mock()
 
     values = np.zeros(8)
     sink.add_histogram("weights/actor/fc1", values, env_step=5)
 
     mock.Histogram.assert_called_once_with(values)
-    mock.log.assert_called_once_with(
+    mock_run.log.assert_called_once_with(
         {"weights/actor/fc1": ("HISTOGRAM", values)}, step=5
     )
 
@@ -106,3 +106,31 @@ def test_flush_is_noop(mock_wandb, monkeypatch):
 
     # Should not raise; nothing to assert on the mock besides no exception.
     sink.flush()
+
+
+def test_two_sinks_log_to_their_own_runs(monkeypatch):
+    """Two coexisting _WandbSink instances must not cross-write to each other."""
+    from unittest.mock import MagicMock
+    from tensoraerospace.agent.metrics import writer as writer_mod
+    from tensoraerospace.agent.metrics.writer import _WandbSink
+
+    mock = MagicMock()
+    mock.Histogram = MagicMock(side_effect=lambda v: ("H", v))
+    mock.Settings = MagicMock(return_value="S")
+    run_a = MagicMock(name="run_a")
+    run_b = MagicMock(name="run_b")
+    mock.init = MagicMock(side_effect=[run_a, run_b])
+    monkeypatch.setattr(writer_mod, "wandb", mock, raising=False)
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+
+    sink_a = _WandbSink(project="A", entity=None, run_name=None, tags=None, config=None)
+    sink_b = _WandbSink(project="B", entity=None, run_name=None, tags=None, config=None)
+
+    sink_a.add_scalar("loss/actor", 1.0, env_step=1)
+    sink_b.add_scalar("loss/critic", 2.0, env_step=1)
+
+    run_a.log.assert_called_once_with({"loss/actor": 1.0}, step=1)
+    run_b.log.assert_called_once_with({"loss/critic": 2.0}, step=1)
+    # No cross-contamination
+    assert run_a.log.call_count == 1
+    assert run_b.log.call_count == 1

--- a/tests/agents/metrics_wandb_sink_test.py
+++ b/tests/agents/metrics_wandb_sink_test.py
@@ -1,0 +1,108 @@
+"""Behaviour of tensoraerospace.agent.metrics.writer._WandbSink."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from tensoraerospace.agent.metrics import writer as writer_mod
+
+
+@pytest.fixture
+def mock_wandb(monkeypatch):
+    """Provide a fresh mock for the `wandb` module attribute on writer module."""
+    mock = MagicMock()
+    mock.Histogram = MagicMock(side_effect=lambda v: ("HISTOGRAM", v))
+    mock.Settings = MagicMock(return_value="SETTINGS_OBJ")
+    mock_run = MagicMock()
+    mock.init = MagicMock(return_value=mock_run)
+    monkeypatch.setattr(writer_mod, "wandb", mock, raising=False)
+    return mock, mock_run
+
+
+def test_init_calls_wandb_init_with_kwargs(mock_wandb, monkeypatch):
+    from tensoraerospace.agent.metrics.writer import _WandbSink
+    mock, mock_run = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+
+    _WandbSink(
+        project="proj-1",
+        entity="ent-1",
+        run_name="run-1",
+        tags=["sac", "pendulum"],
+        config={"lr": 1e-3},
+    )
+
+    mock.login.assert_not_called()
+    mock.init.assert_called_once()
+    kwargs = mock.init.call_args.kwargs
+    assert kwargs["project"] == "proj-1"
+    assert kwargs["entity"] == "ent-1"
+    assert kwargs["name"] == "run-1"
+    assert kwargs["tags"] == ["sac", "pendulum"]
+    assert kwargs["config"] == {"lr": 1e-3}
+    assert kwargs["reinit"] is True
+    assert kwargs["settings"] == "SETTINGS_OBJ"
+
+
+def test_init_calls_login_when_api_key_missing(mock_wandb, monkeypatch):
+    from tensoraerospace.agent.metrics.writer import _WandbSink
+    mock, _ = mock_wandb
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+
+    _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+
+    mock.login.assert_called_once()
+    mock.init.assert_called_once()
+
+
+def test_add_scalar_calls_wandb_log(mock_wandb, monkeypatch):
+    from tensoraerospace.agent.metrics.writer import _WandbSink
+    mock, _ = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+    sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+    mock.log.reset_mock()
+
+    sink.add_scalar("loss/actor", 0.123, env_step=10)
+
+    mock.log.assert_called_once_with({"loss/actor": 0.123}, step=10)
+
+
+def test_add_histogram_wraps_in_wandb_histogram(mock_wandb, monkeypatch):
+    from tensoraerospace.agent.metrics.writer import _WandbSink
+    mock, _ = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+    sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+    mock.log.reset_mock()
+
+    values = np.zeros(8)
+    sink.add_histogram("weights/actor/fc1", values, env_step=5)
+
+    mock.Histogram.assert_called_once_with(values)
+    mock.log.assert_called_once_with(
+        {"weights/actor/fc1": ("HISTOGRAM", values)}, step=5
+    )
+
+
+def test_close_calls_finish_once(mock_wandb, monkeypatch):
+    from tensoraerospace.agent.metrics.writer import _WandbSink
+    mock, mock_run = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+    sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+
+    sink.close()
+    sink.close()  # second call must be a no-op
+
+    mock_run.finish.assert_called_once()
+
+
+def test_flush_is_noop(mock_wandb, monkeypatch):
+    from tensoraerospace.agent.metrics.writer import _WandbSink
+    mock, _ = mock_wandb
+    monkeypatch.setenv("WANDB_API_KEY", "fake-key")
+    sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
+
+    # Should not raise; nothing to assert on the mock besides no exception.
+    sink.flush()

--- a/tests/agents/metrics_wandb_sink_test.py
+++ b/tests/agents/metrics_wandb_sink_test.py
@@ -24,6 +24,7 @@ def mock_wandb(monkeypatch):
 
 def test_init_calls_wandb_init_with_kwargs(mock_wandb, monkeypatch):
     from tensoraerospace.agent.metrics.writer import _WandbSink
+
     mock, mock_run = mock_wandb
     monkeypatch.setenv("WANDB_API_KEY", "fake-key")
 
@@ -49,6 +50,7 @@ def test_init_calls_wandb_init_with_kwargs(mock_wandb, monkeypatch):
 
 def test_init_calls_login_when_api_key_missing(mock_wandb, monkeypatch):
     from tensoraerospace.agent.metrics.writer import _WandbSink
+
     mock, _ = mock_wandb
     monkeypatch.delenv("WANDB_API_KEY", raising=False)
 
@@ -60,6 +62,7 @@ def test_init_calls_login_when_api_key_missing(mock_wandb, monkeypatch):
 
 def test_add_scalar_calls_wandb_log(mock_wandb, monkeypatch):
     from tensoraerospace.agent.metrics.writer import _WandbSink
+
     mock, mock_run = mock_wandb
     monkeypatch.setenv("WANDB_API_KEY", "fake-key")
     sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
@@ -72,6 +75,7 @@ def test_add_scalar_calls_wandb_log(mock_wandb, monkeypatch):
 
 def test_add_histogram_wraps_in_wandb_histogram(mock_wandb, monkeypatch):
     from tensoraerospace.agent.metrics.writer import _WandbSink
+
     mock, mock_run = mock_wandb
     monkeypatch.setenv("WANDB_API_KEY", "fake-key")
     sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
@@ -88,6 +92,7 @@ def test_add_histogram_wraps_in_wandb_histogram(mock_wandb, monkeypatch):
 
 def test_close_calls_finish_once(mock_wandb, monkeypatch):
     from tensoraerospace.agent.metrics.writer import _WandbSink
+
     mock, mock_run = mock_wandb
     monkeypatch.setenv("WANDB_API_KEY", "fake-key")
     sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
@@ -100,6 +105,7 @@ def test_close_calls_finish_once(mock_wandb, monkeypatch):
 
 def test_flush_is_noop(mock_wandb, monkeypatch):
     from tensoraerospace.agent.metrics.writer import _WandbSink
+
     mock, _ = mock_wandb
     monkeypatch.setenv("WANDB_API_KEY", "fake-key")
     sink = _WandbSink(project="p", entity=None, run_name=None, tags=None, config=None)
@@ -111,6 +117,7 @@ def test_flush_is_noop(mock_wandb, monkeypatch):
 def test_two_sinks_log_to_their_own_runs(monkeypatch):
     """Two coexisting _WandbSink instances must not cross-write to each other."""
     from unittest.mock import MagicMock
+
     from tensoraerospace.agent.metrics import writer as writer_mod
     from tensoraerospace.agent.metrics.writer import _WandbSink
 

--- a/tests/agents/metrics_writer_test.py
+++ b/tests/agents/metrics_writer_test.py
@@ -94,11 +94,10 @@ def test_close_does_not_raise(writer: MetricWriter):
     writer.close()
 
 
-def test_metricwriter_with_wandb_project_creates_two_sinks(
-    tmp_path: Path, monkeypatch
-):
+def test_metricwriter_with_wandb_project_creates_two_sinks(tmp_path: Path, monkeypatch):
     """When both tb_log_dir and wandb_project are passed, both sinks are active."""
     from unittest.mock import MagicMock
+
     from tensoraerospace.agent.metrics import writer as writer_mod
 
     mock_wandb = MagicMock()

--- a/tests/agents/metrics_writer_test.py
+++ b/tests/agents/metrics_writer_test.py
@@ -16,7 +16,7 @@ from tensoraerospace.agent.metrics import (
 
 @pytest.fixture
 def writer(tmp_path: Path) -> MetricWriter:
-    return MetricWriter(log_dir=str(tmp_path / "tb"), algo="test")
+    return MetricWriter(tb_log_dir=str(tmp_path / "tb"), algo="test")
 
 
 def test_add_scalar_accepts_registered_tag(writer: MetricWriter):
@@ -38,7 +38,7 @@ def test_add_scalar_rejects_bad_worker_suffix(writer: MetricWriter):
 
 
 def test_add_scalar_strict_false_allows_anything(tmp_path: Path):
-    w = MetricWriter(log_dir=str(tmp_path / "tb"), strict=False)
+    w = MetricWriter(tb_log_dir=str(tmp_path / "tb"), strict=False)
     w.add_scalar("anything/at/all", 1.0, env_step=1)
 
 
@@ -92,3 +92,35 @@ def test_assert_contract_passes_when_complete(writer: MetricWriter):
 
 def test_close_does_not_raise(writer: MetricWriter):
     writer.close()
+
+
+def test_metricwriter_with_wandb_project_creates_two_sinks(
+    tmp_path: Path, monkeypatch
+):
+    """When both tb_log_dir and wandb_project are passed, both sinks are active."""
+    from unittest.mock import MagicMock
+    from tensoraerospace.agent.metrics import writer as writer_mod
+
+    mock_wandb = MagicMock()
+    mock_wandb.init = MagicMock(return_value=MagicMock())
+    mock_wandb.Settings = MagicMock(return_value="S")
+    monkeypatch.setattr(writer_mod, "wandb", mock_wandb, raising=False)
+    monkeypatch.setenv("WANDB_API_KEY", "fake")
+
+    w = MetricWriter(
+        tb_log_dir=str(tmp_path / "tb"),
+        wandb_project="exp",
+        algo="test",
+    )
+    assert len(w._sinks) == 2  # noqa: SLF001 — internal but stable for tests
+
+
+def test_metricwriter_no_kwargs_creates_zero_sinks(monkeypatch):
+    """No tb_log_dir and no wandb activation => zero sinks (writer no-ops)."""
+    monkeypatch.delenv("WANDB_API_KEY", raising=False)
+    w = MetricWriter(algo="test")
+    assert len(w._sinks) == 0
+    # whitelist still enforced
+    w.add_scalar(schema.LOSS_ACTOR, 0.5, env_step=1)
+    with pytest.raises(ValueError):
+        w.add_scalar("not/in/schema", 0.5, env_step=1)


### PR DESCRIPTION
# Pull Request

## 📋 Description

Adds Weights & Biases as a second sink for `MetricWriter` alongside the existing TensorBoard sink. Both backends can run in parallel — every `add_scalar` / `add_histogram` / `log_episode` call fans out to whichever sinks are enabled. Builds directly on the unified-metrics work in #215.

The architecture is a small façade refactor: `MetricWriter` becomes a thin wrapper holding `0..N` private `_Sink` objects (`_TensorBoardSink`, `_WandbSink`). Strict-whitelist validation stays in the façade — sinks never validate. A new test file pins per-run isolation under `reinit=True` (each `_WandbSink` writes through its own captured run object, not the wandb global state).

**Activation rules (auto-detect + explicit override):**

| `tb_log_dir` | `wandb_project` | `WANDB_API_KEY` | TB | wandb |
|---|---|---|---|---|
| set | — | — | ✅ | — |
| set | — | set | ✅ | ✅ (project = `algo`) |
| — | — | set | — | ✅ (project = `algo`) |
| set | set | * | ✅ | ✅ (project as given) |
| — | set | unset | — | ✅ (calls `wandb.login()` interactively) |
| — | — | unset | — | — |

**Per-agent kwargs (all 12 RL agents):**
```python
agent = SAC(
    env=env,
    log_dir="runs/sac",                       # TB on
    wandb_project="my-experiment",            # wandb on
    wandb_entity=None,
    wandb_run_name=None,                       # default = f"{algo}-{timestamp}"
    wandb_tags=None,                           # default = [algo]
    wandb_config={"lr": 3e-4, "tau": 5e-3},   # hyperparams stored on the run
)
```

**A3C limitation (documented):** wandb-sink is parent-only. Workers (forked) skip wandb-init even if `WANDB_API_KEY` is set. They keep writing to the parent's TensorBoard event file via the `/worker_<id>` suffix introduced in #215.

## 🔗 Related Issues

Closes #176

## 🎯 Type of change
- [x] ✨ New feature (wandb backend, dual-sink fan-out, auto-detection via env var)
- [ ] 💥 Breaking change — *minor:* `MetricWriter`'s first positional kwarg renamed `log_dir` → `tb_log_dir`. Positional callers (all 12 agents inside this repo) are unaffected; external code using the keyword form needs `tb_log_dir=` instead.
- [x] 📚 Documentation update (`docs/en/guide/metrics.md` gains a "Wandb backend" section)
- [x] 🧹 Code refactor (extracted `_TensorBoardSink` from `MetricWriter` as a behavior-preserving step)
- [x] 🧪 Tests (4 new test files: 6 sink unit tests + 10 factory auto-detect tests + 3 A3C parent-only tests + 1 dual-sink end-to-end smoke test, plus 2 added to existing writer test file)

## 🧪 How has this been tested?

- [x] Unit tests (`metrics_wandb_sink_test.py`, `metrics_factory_test.py`, `metrics_writer_test.py`)
- [x] Per-agent smoke tests (existing 12 files unchanged; default behavior — `WANDB_API_KEY` unset — preserves TB-only)
- [x] Dual-sink end-to-end (`metrics_dual_sink_smoke_test.py` runs SAC for 1 episode, asserts the same set of canonical tags appears in both the TB event file and the mocked `wandb.log` calls)
- [x] A3C parent-only guard (`a3c_wandb_parent_only_test.py`)
- [x] Per-run isolation under `reinit=True` (`test_two_sinks_log_to_their_own_runs` in `metrics_wandb_sink_test.py`) — added after a code review caught a real bug where module-level `wandb.log()` was routing through wandb's global active-run state.

**Test commands:**
```bash
.venv/bin/python -m pytest tests/agents/metrics_*.py tests/agents/a3c_wandb_parent_only_test.py -v
# 41 passed (6 sink + 10 factory + 14 writer + 1 contract + 7 schema + 3 a3c-parent-only)

.venv/bin/python -m pytest tests/ --tb=no
# 1746 passed
```

## 📸 Screenshots (if applicable)

—

## ✅ Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] I have updated the documentation as needed (`docs/en/guide/metrics.md`)
- [x] My changes do not introduce new warnings
- [x] I added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published downstream

## 🔍 Additional notes

**Migration impact for users:**
1. Default behavior is unchanged when `WANDB_API_KEY` is unset — existing TB-only workflows continue to work without modification.
2. Setting `WANDB_API_KEY` in the environment is the simplest way to opt in: every agent will start mirroring metrics to a wandb run named `<algo>-<timestamp>` in a project named after `algo`.
3. For full control, pass `wandb_project=...` (and optionally `wandb_entity`, `wandb_run_name`, `wandb_tags`, `wandb_config`) to the agent's `__init__`.
4. `MetricWriter`'s first positional kwarg is now `tb_log_dir`. All in-repo callers used positional, so this is a no-op for the codebase. External users who imported `MetricWriter` directly with `log_dir=KEYWORD` need to rename to `tb_log_dir=`.
5. `_WandbSink` initialization calls `wandb.login()` if `WANDB_API_KEY` is missing AND `wandb_project` was passed explicitly. In CI without a TTY, wandb itself raises a clear error.

**Architecture notes:**
- `_WandbSink.add_scalar` / `add_histogram` route through `self._run.log(...)`, NOT module-level `wandb.log(...)`. This isolates each writer from wandb's global "currently active run" state and lets two writers coexist without cross-contamination (relevant for users who instantiate multiple agents in one process).
- `wandb.init(reinit=True, settings=wandb.Settings(start_method="thread"))` — `reinit` allows multiple writers per process (notebook re-runs); thread start method avoids `gRPC` deadlocks under `multiprocessing.fork` (relevant for A3C).
- `flush()` on `_WandbSink` is intentionally a no-op — wandb buffers asynchronously and there is no public API to force a flush. `close()` calls `wandb.finish()` exactly once (idempotent).

**What does NOT change:**
- TensorBoard event-file format and the canonical schema from #215.
- The strict whitelist enforcement on `add_scalar` / `add_histogram` — unknown tags still fail loud at the writer level, regardless of which sinks are active.
- The mandatory-minimum contract enforced by `assert_contract_satisfied()` — unaffected by sink choice.
- A3C's multi-worker behavior (workers continue writing to the parent's TB event file with `/worker_<id>` suffix).

**Specification and plan:**
- `docs/superpowers/specs/2026-04-20-wandb-backend-design.md`
- `docs/superpowers/plans/2026-04-20-wandb-backend.md`

## 📊 Performance impact
- [x] No performance impact (logging adds at most one `wandb.log({...}, step=...)` call per metric, batched and uploaded asynchronously by wandb's background thread)

## 🔒 Security
- [x] These changes do not introduce security vulnerabilities
- [ ] I ran bandit and safety checks
- [x] No secrets or keys are included in the code (`WANDB_API_KEY` is read from env, never written or logged)
