### PR TITLE
ci(version-gate): allow release-prep bumps via --check-release-ready

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -41,9 +41,15 @@ jobs:
           poetry config virtualenvs.create true
           poetry config virtualenvs.in-project true
 
-      - name: 🏷️ Verify pyproject version matches latest stable tag
+      - name: 🏷️ Verify pyproject version is release-ready vs latest stable tag
+        # Release-prep PRs (e.g. ``develop -> main`` with a version bump) need
+        # ``pyproject.toml`` to land BEFORE the matching tag exists, so a strict
+        # equality check would always fail. ``--check-release-ready`` accepts
+        # either equality with the latest stable tag or a single-step increment
+        # (patch+1, minor+1.0, or major+1.0.0). The strict equality check still
+        # runs at release publish time via ``--check-tag`` in publish.yml.
         run: |
-          poetry run python scripts/version_gate.py --check-latest-tag
+          poetry run python scripts/version_gate.py --check-release-ready
 
   test:
     name: 🐍 Test Python ${{ matrix.python-version }}

--- a/scripts/version_gate.py
+++ b/scripts/version_gate.py
@@ -15,6 +15,7 @@ DEFAULT_PYPROJECT = ROOT / "pyproject.toml"
 SECTION_RE = re.compile(r"^\[[^\]]+\]\s*$")
 STABLE_TAG_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$")
 TAG_VERSION_RE = re.compile(r"^v?([0-9]+[.][0-9]+[.][0-9]+[A-Za-z0-9.+_-]*)$")
+STABLE_VERSION_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 VERSION_LINE_RE = re.compile(
     r'^(?P<prefix>\s*version\s*=\s*")(?P<version>[^"]+)(?P<suffix>".*)$'
 )
@@ -134,6 +135,78 @@ def check_version(pyproject_version: str, expected_version: str, source: str) ->
     return False
 
 
+def parse_stable_version(version: str) -> tuple[int, int, int] | None:
+    match = STABLE_VERSION_RE.match(version)
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+def is_valid_next_increment(
+    latest_key: tuple[int, int, int], candidate_key: tuple[int, int, int]
+) -> bool:
+    """Return True iff ``candidate_key`` is exactly one valid semver increment ahead.
+
+    Acceptable increments relative to a latest tag ``X.Y.Z``:
+      * patch:  ``X.Y.(Z+1)``
+      * minor:  ``X.(Y+1).0``
+      * major:  ``(X+1).0.0``
+    """
+    lmaj, lmin, lpatch = latest_key
+    return candidate_key in {
+        (lmaj, lmin, lpatch + 1),
+        (lmaj, lmin + 1, 0),
+        (lmaj + 1, 0, 0),
+    }
+
+
+def check_release_ready(pyproject_version: str, latest: StableTag) -> bool:
+    """Allow ``pyproject_version`` to either match ``latest`` or be one step ahead.
+
+    Used by the pre-merge gate on release-prep PRs so the version bump can land
+    on the integration branch before the matching tag exists.
+    """
+    if pyproject_version == latest.version:
+        print(
+            f"PASS: pyproject.toml version {pyproject_version} matches "
+            f"latest stable tag {latest.tag}."
+        )
+        return True
+
+    candidate_key = parse_stable_version(pyproject_version)
+    if candidate_key is None:
+        print(
+            f"FAIL: pyproject.toml version '{pyproject_version}' is not a stable "
+            "semver string (X.Y.Z); release-prep gate requires a clean release version.",
+            file=sys.stderr,
+        )
+        return False
+
+    if is_valid_next_increment(latest.key, candidate_key):
+        print(
+            f"PASS: pyproject.toml version {pyproject_version} is a valid next "
+            f"increment from latest stable tag {latest.tag} ({latest.version})."
+        )
+        return True
+
+    lmaj, lmin, lpatch = latest.key
+    expected = ", ".join(
+        [
+            latest.version,
+            f"{lmaj}.{lmin}.{lpatch + 1}",
+            f"{lmaj}.{lmin + 1}.0",
+            f"{lmaj + 1}.0.0",
+        ]
+    )
+    print(
+        f"FAIL: pyproject.toml version {pyproject_version} is not aligned with "
+        f"latest stable tag {latest.tag} ({latest.version}). "
+        f"Expected one of: {expected}.",
+        file=sys.stderr,
+    )
+    return False
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--pyproject", type=Path, default=DEFAULT_PYPROJECT)
@@ -142,6 +215,16 @@ def parse_args() -> argparse.Namespace:
         "--check-latest-tag",
         action="store_true",
         help="Require pyproject.toml version to match the latest stable git tag.",
+    )
+    parser.add_argument(
+        "--check-release-ready",
+        action="store_true",
+        help=(
+            "Require pyproject.toml version to either match the latest stable git "
+            "tag or be a valid one-step increment (patch+1, minor+1.0, or "
+            "major+1.0.0). Use this on release-prep PRs so the version bump can "
+            "land before the matching tag exists."
+        ),
     )
     parser.add_argument(
         "--check-tag",
@@ -175,6 +258,12 @@ def main() -> int:
             if not check_version(
                 pyproject_version, latest.version, f"latest stable tag {latest.tag}"
             ):
+                return 1
+
+        if args.check_release_ready:
+            did_work = True
+            latest = latest_stable_tag()
+            if not check_release_ready(pyproject_version, latest):
                 return 1
 
         if args.check_tag:


### PR DESCRIPTION
## 📋 Description
The pre-merge **`🏷️ Version Tag Gate`** in `action.yml` calls `scripts/version_gate.py --check-latest-tag`, which **strictly** requires `pyproject.toml.version == latest stable git tag`. By construction this fails on every release-prep PR (`develop → main` carrying the `X.Y.Z` bump), because the matching tag does not exist yet.

This blocks the current release flow:
- PR #234 (`develop → main`, bump `0.3.13 → 0.3.14`) currently fails the gate.
- The previous `v0.3.14` release attempt ([run 25241426084](https://github.com/TensorAeroSpace/TensorAeroSpace/actions/runs/25241426084)) had to invert the order (tag first, bump after) which then failed `--check-tag` instead — same chicken-and-egg, opposite end.

## 🔧 Fix
Introduce a new mode `--check-release-ready` that accepts the version when:
- it **equals** the latest stable tag (post-release steady state), **or**
- it is a **valid one-step semver increment** ahead of the latest stable tag:
  - patch: `X.Y.(Z+1)`
  - minor: `X.(Y+1).0`
  - major: `(X+1).0.0`

Anything else (regression, version skip, non-semver) still fails. Switch `action.yml`'s pre-merge gate to use the new mode.

`publish.yml` keeps the strict checks unchanged:
- `--check-tag <tag>` on `release: published` — guarantees tag and pyproject agree before PyPI publish.
- `--check-latest-tag` on manual PyPI dispatch — guarantees you only publish a tagged version manually.

So we relax only the *pre-merge* gate; the *publish* gate is still strict.

## 🎯 Type of change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🧹 Code refactor
- [ ] ⚡ Performance improvement
- [ ] 🧪 Tests
- [x] 🔧 CI/CD changes

## 🧪 How has this been tested?
Local runs against the current state (`pyproject.toml = 0.3.14`, latest tag = `v0.3.13`):

```
$ python3 scripts/version_gate.py --check-release-ready
PASS: pyproject.toml version 0.3.14 is a valid next increment from latest stable tag v0.3.13 (0.3.13).
$ python3 scripts/version_gate.py --check-latest-tag
FAIL: pyproject.toml version 0.3.14 does not match latest stable tag v0.3.13 (0.3.13).
$ python3 scripts/version_gate.py --check-tag v0.3.14
PASS: pyproject.toml version 0.3.14 matches tag v0.3.14.
$ python3 scripts/version_gate.py --check-tag v0.3.15
FAIL: pyproject.toml version 0.3.14 does not match tag v0.3.15 (0.3.15).
```

`is_valid_next_increment` was unit-checked against:
- equality (excluded, handled by wrapper) — rejected ✅
- patch +1, minor +1.0, major +1.0.0 — accepted ✅
- patch regression, patch jump (+2), minor +1.x with patch ≠ 0, minor jump, major +1.x.y with tail ≠ 0, major jump — all rejected ✅

- [x] Unit tests (logic verified locally; full unit test for `is_valid_next_increment` can be added if requested)
- [ ] Integration tests
- [x] Manual testing
- [ ] Performance testing

**Test commands:**
```bash
poetry run python scripts/version_gate.py --check-release-ready
poetry run python scripts/version_gate.py --check-latest-tag
poetry run python scripts/version_gate.py --check-tag v0.3.14
```

## ✅ Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added comments where necessary
- [x] I have updated the documentation as needed (`--help` / step comment)
- [x] My changes do not introduce new warnings
- [x] I added tests that prove my fix is effective or my feature works (logic checked by direct invocation)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published downstream

## 🔍 Additional notes
- This is a **non-breaking** change. Existing flags (`--check-latest-tag`, `--check-tag`, `--sync-latest-tag`, `--print`) keep their semantics.
- After this PR merges into `develop`, PR #234 (`develop → main`, bump to `0.3.14`) will pass `🏷️ Version Tag Gate` automatically — no other changes needed.
- After PR #234 merges into `main`, creating GitHub Release `v0.3.14` on the merge commit triggers `publish.yml`, where `--check-tag v0.3.14` will pass because pyproject was bumped to `0.3.14` first.

## 📊 Performance impact
- [x] No performance impact

## 🔒 Security
- [x] These changes do not introduce security vulnerabilities
- [x] I ran bandit and safety checks
- [x] No secrets or keys are included in the code
