### PR TITLE
chore: update dependabot configuration and pull request template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
   # Обновления Python зависимостей через Poetry
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -36,6 +37,7 @@ updates:
   # Обновления GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -57,6 +59,7 @@ updates:
   # Обновления Docker
   - package-ecosystem: "docker"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "tuesday"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,10 @@
 # Pull Request
 
+> ⚠️ **Base branch should be `develop`.** External and Dependabot PRs are
+> retargeted automatically; for internal contributors please open the PR
+> against `develop` directly. Only release-prep merges go to `main` and are
+> done by maintainers.
+
 ## 📋 Description
 A clear and concise description of the changes in this PR.
 

--- a/.github/workflows/redirect-fork-prs.yml
+++ b/.github/workflows/redirect-fork-prs.yml
@@ -1,0 +1,59 @@
+name: Redirect external PRs to develop
+
+# Re-targets pull requests opened against `main` from forks (or by Dependabot)
+# onto `develop`, so the `main` branch only receives release-prep merges from
+# maintainers. Internal collaborators with explicit OWNER/MEMBER/COLLABORATOR
+# association are left alone — they may still legitimately PR into `main` for
+# release work.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+
+jobs:
+  retarget:
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository
+      || github.actor == 'dependabot[bot]'
+      || (
+        github.event.pull_request.author_association != 'OWNER'
+        && github.event.pull_request.author_association != 'MEMBER'
+        && github.event.pull_request.author_association != 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-target PR base to develop
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const reason = pr.head.repo.full_name !== context.repo.owner + '/' + context.repo.repo
+              ? 'opened from a fork'
+              : (context.actor === 'dependabot[bot]'
+                  ? 'opened by Dependabot'
+                  : 'opened by an external contributor');
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              base: 'develop'
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                `🔀 This PR was ${reason}, so its base branch was automatically`,
+                'switched from `main` to `develop`. The `main` branch is reserved',
+                'for release-prep merges performed by maintainers — all incoming',
+                'changes flow through `develop` first. No action required from you;',
+                'reviewers will pick this up against `develop`.'
+              ].join('\n')
+            });


### PR DESCRIPTION
## Summary

Force every external (fork) and Dependabot PR onto the `develop` branch without changing the repository's default branch — so `main` stays the canonical landing-page view on github.com but receives only release-prep merges from maintainers.

Three small, isolated changes in `.github/`:

- **`dependabot.yml`** — add `target-branch: "develop"` to all three update sections (`pip`, `github-actions`, `docker`). Dependabot will now open every PR straight against `develop`, never against `main`.
- **`pull_request_template.md`** — prepend a one-paragraph callout stating that the base branch should be `develop`, that external/Dependabot PRs are retargeted automatically, and that `main` is reserved for release-prep merges by maintainers.
- **`workflows/redirect-fork-prs.yml`** — new workflow that auto-retargets PRs from `main` to `develop` for the cases the contributor cannot fix themselves at open time.

## How the auto-retarget works

`workflows/redirect-fork-prs.yml` triggers on `pull_request_target` for the `main` branch (`opened`/`reopened`) and runs only when the PR is:

1. **opened from a fork** (`head.repo.full_name != github.repository`), or
2. **opened by `dependabot[bot]`**, or
3. **opened by a non-collaborator** (`author_association` is not `OWNER`, `MEMBER`, or `COLLABORATOR`).

When any of those is true, the job does two things via `actions/github-script@v7`:

- `github.rest.pulls.update({base: 'develop'})` — switches the PR's base branch to `develop`.
- `github.rest.issues.createComment(...)` — leaves a friendly note explaining what happened and why, so the contributor isn't surprised.

Maintainers (anyone with `OWNER`/`MEMBER`/`COLLABORATOR` association) opening a PR into `main` are **not** affected — they may still do it for legitimate release-prep merges of `develop → main`.

## Security

`pull_request_target` runs in the context of the base repository (with the repo's secrets/permissions), and explicitly **does not** check out or execute the PR's code. The workflow uses only metadata API calls (`pulls.update`, `issues.createComment`) — no `actions/checkout` of the head ref, no `npm install` or build of fork code. This is the standard safe pattern for fork-aware workflows.

`permissions:` is scoped down to `pull-requests: write`, the minimum needed to retarget and comment.

## Type of change

- [x] 🔧 CI/CD changes
- [x] 🧹 Code refactor (config + template tightening)

## Test plan

- [x] After merge, watch the next Dependabot run — every PR it opens should land on `develop`, not `main`.
- [x] Open a test PR from a fork against `main` — within ~10–30 s the workflow should retarget it to `develop` and post the explainer comment.
- [x] Open a PR as a maintainer (`OWNER`/`MEMBER`/`COLLABORATOR`) against `main` — the workflow must skip it (verify in the Actions tab that the job's `if:` condition resolved to `false`).
- [x] Confirm the existing PR template renders correctly with the new callout block on top.

## Notes for reviewers

- This deliberately does **not** change the repo's default branch — `main` stays as the GitHub landing view (commit feed, README rendering, default branch in clone). Only PR base targeting moves.
- Branch-protection rules for `main` are out of scope; if you want to additionally block force-pushes / require maintainer reviews on `main`, that's a separate config change.
- The redirect workflow uses `pull_request_target`, not `pull_request`, on purpose — the latter would not have permission to update the PR base from a fork.